### PR TITLE
feat: payment verified email + fix mobile Google sign-in

### DIFF
--- a/app/api/shop/[orderId]/approve-payment/route.ts
+++ b/app/api/shop/[orderId]/approve-payment/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { isPayloadAdmin } from "../../../../../lib/auth";
+import { sendPaymentVerifiedEmail } from "../../../../../lib/email";
 import { getPayloadClient } from "../../../../../lib/payload";
 import { transferOrderFiles } from "../../../../../lib/r2";
 
@@ -76,6 +77,31 @@ export async function POST(request: NextRequest, context: RouteContext) {
 			},
 		});
 
+		// Send "payment verified — select pickup slot" email to the customer
+		try {
+			const customer =
+				typeof order.customer === "object" && order.customer !== null
+					? order.customer
+					: await payload.findByID({
+							collection: "customers",
+							id: order.customer as string,
+						});
+
+			if (customer?.email) {
+				const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "";
+				await sendPaymentVerifiedEmail({
+					to: customer.email as string,
+					customerName: (customer.name as string) || "",
+					orderNumber: order.orderNumber || "",
+					total: order.pricing?.total,
+					orderUrl: baseUrl ? `${baseUrl}/my-orders` : undefined,
+				});
+			}
+		} catch (emailError) {
+			// Log but don't fail the request — the order is already updated
+			console.error("Failed to send payment verified email:", emailError);
+		}
+
 		return NextResponse.json({
 			success: true,
 			order: {
@@ -84,7 +110,8 @@ export async function POST(request: NextRequest, context: RouteContext) {
 				status: updated.status,
 				paidAt: updated.paidAt,
 			},
-			message: "Payment approved. Files transferred to permanent storage.",
+			message:
+				"Payment approved. Files transferred to permanent storage. Customer notified to select pickup slot.",
 		});
 	} catch (error) {
 		console.error("Error approving payment:", error);

--- a/components/ordercontainer/Cart.tsx
+++ b/components/ordercontainer/Cart.tsx
@@ -148,7 +148,7 @@ const Cart = ({
 	setIsProcessing,
 	setCurrentlyUploading,
 }: Props) => {
-	const { cartPackages, uploadedPdfs, displayPriceString } =
+	const { cartPackages, uploadedPdfs, displayPriceString, persistCart } =
 		useContext(CartContext);
 	const { isAuthenticated, isLoading: authLoading, login } = useAuth();
 	const [isCreatingOrder, setIsCreatingOrder] = useState(false);
@@ -168,6 +168,8 @@ const Cart = ({
 		}
 
 		if (!isAuthenticated) {
+			// Persist uploaded files to IndexedDB before redirecting for OAuth
+			await persistCart();
 			login();
 			return;
 		}
@@ -226,6 +228,7 @@ const Cart = ({
 		cartPackages.length,
 		isAuthenticated,
 		login,
+		persistCart,
 		onProceedToPayment,
 		setIsProcessing,
 		setCurrentlyUploading,
@@ -277,7 +280,13 @@ const Cart = ({
 						</Button>
 					) : (
 						<Box display="flex" flexDir="column" gap={2}>
-							<Button variant="browned" onClick={login}>
+							<Button
+								variant="browned"
+								onClick={async () => {
+									await persistCart();
+									login();
+								}}
+							>
 								Sign in to Order
 							</Button>
 							<Text fontSize="xs" color="gray.500" textAlign="center">

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -1,8 +1,9 @@
 import type { Session } from "next-auth";
-import { SessionProvider, signOut, useSession } from "next-auth/react";
+import { signIn, SessionProvider, signOut, useSession } from "next-auth/react";
 import {
 	createContext,
 	type PropsWithChildren,
+	useCallback,
 	useContext,
 	useMemo,
 } from "react";
@@ -50,6 +51,14 @@ const AuthContext = createContext<CustomerSession>({
 function AuthContextInner({ children }: PropsWithChildren) {
 	const { data: session, status } = useSession();
 
+	const login = useCallback(() => {
+		// Use a full-page redirect for OAuth sign-in.
+		// Uploaded files are persisted to IndexedDB by the Cart before calling
+		// login(), and restored from IndexedDB when the page reloads after auth.
+		sessionStorage.setItem("auth-return-url", window.location.href);
+		signIn("google", { callbackUrl: "/auth/callback" });
+	}, []);
+
 	const value = useMemo<CustomerSession>(() => {
 		const isLoading = status === "loading";
 		const isAuthenticated = status === "authenticated" && !!session;
@@ -61,22 +70,10 @@ function AuthContextInner({ children }: PropsWithChildren) {
 			name: session?.user?.name ?? null,
 			email: session?.user?.email ?? null,
 			image: session?.user?.image ?? null,
-			login: () => {
-				// Open OAuth in a popup so the current page state (uploaded files) is preserved
-				const width = 500;
-				const height = 600;
-				const left = window.screenX + (window.outerWidth - width) / 2;
-				const top = window.screenY + (window.outerHeight - height) / 2;
-				const callbackUrl = encodeURIComponent("/auth/callback");
-				window.open(
-					`/api/auth/signin?callbackUrl=${callbackUrl}`,
-					"google-signin",
-					`width=${width},height=${height},left=${left},top=${top}`,
-				);
-			},
+			login,
 			logout: () => signOut({ callbackUrl: "/" }),
 		};
-	}, [session, status]);
+	}, [session, status, login]);
 
 	return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -1,5 +1,5 @@
 import type { Session } from "next-auth";
-import { signIn, SessionProvider, signOut, useSession } from "next-auth/react";
+import { SessionProvider, signIn, signOut, useSession } from "next-auth/react";
 import {
 	createContext,
 	type PropsWithChildren,

--- a/contexts/CartContext.tsx
+++ b/contexts/CartContext.tsx
@@ -1,7 +1,13 @@
-import { createContext, useCallback, useEffect, useState } from "react";
+import { createContext, useCallback, useEffect, useRef, useState } from "react";
+import {
+	clearCartPdfs,
+	loadCartPdfs,
+	saveCartPdfs,
+	type StoredPdfItem,
+} from "../lib/cartStorage";
 import { getItemsWithBulkDiscount } from "../lib/utils";
 import type CartItem from "../types/models/CartItem";
-import type PdfCartItem from "../types/models/PdfCartItem";
+import PdfCartItem from "../types/models/PdfCartItem";
 
 type cartPackageOperation = (cartPackage: CartItem) => void;
 type cartPdfOperation = (cartPackage: PdfCartItem) => void;
@@ -21,6 +27,8 @@ interface ICartContext {
 	addUploadedPdf: cartPdfOperation;
 	updateUploadedPdf: cartPdfOperation;
 	removeUploadedPdf: cartPdfOperation;
+	/** Persist uploaded PDFs to IndexedDB (call before navigating away). */
+	persistCart: () => Promise<void>;
 }
 
 const defaultCartContext: ICartContext = {
@@ -36,6 +44,7 @@ const defaultCartContext: ICartContext = {
 	addUploadedPdf: (_cartPdf) => {},
 	updateUploadedPdf: (_cartPdf) => {},
 	removeUploadedPdf: (_cartPdf) => {},
+	persistCart: async () => {},
 };
 
 export const CartContext = createContext<ICartContext>(defaultCartContext);
@@ -66,6 +75,66 @@ export function CartContextProvider(
 	);
 	const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 	const [hasDiscountApplied, setHasDiscountApplied] = useState<boolean>(false);
+
+	// Keep a ref to uploadedPdfs so persistCart always sees the latest value
+	const uploadedPdfsRef = useRef(uploadedPdfs);
+	uploadedPdfsRef.current = uploadedPdfs;
+
+	// Restore uploaded PDFs from IndexedDB on mount (e.g. after OAuth redirect)
+	useEffect(() => {
+		async function restore() {
+			try {
+				const stored = await loadCartPdfs();
+				if (stored.length === 0) return;
+
+				const restored = stored.map(
+					(item: StoredPdfItem) =>
+						new PdfCartItem(
+							item.id,
+							item.displayName,
+							item.quantity,
+							item.unitPrice,
+							item.priceId,
+							item.pages,
+							item.isColor,
+							item.file,
+							item.productId,
+						),
+				);
+
+				setUploadedPdfs(restored);
+				// Clear IndexedDB after successful restore
+				await clearCartPdfs();
+			} catch (err) {
+				console.error("Failed to restore cart from IndexedDB:", err);
+			}
+		}
+
+		restore();
+	}, []);
+
+	/**
+	 * Persist the current uploaded PDFs to IndexedDB.
+	 * Call this before navigating away (e.g. OAuth redirect) to preserve files.
+	 */
+	const persistCart = useCallback(async () => {
+		const pdfs = uploadedPdfsRef.current;
+		if (pdfs.length === 0) return;
+
+		const items: StoredPdfItem[] = pdfs.map((pdf) => ({
+			id: pdf.id,
+			displayName: pdf.displayName,
+			quantity: pdf.getQuantity(),
+			unitPrice: pdf.getDisplayPrice() / pdf.getQuantity(),
+			priceId: pdf.priceId,
+			pages: pdf.getPages(),
+			isColor: pdf.isColor,
+			file: pdf.file,
+			productId: pdf.productId,
+		}));
+
+		await saveCartPdfs(items);
+	}, []);
 
 	function addCartPackage(cartPackage: CartItem) {
 		if (alreadyInArray(cartPackages, cartPackage)) {
@@ -138,6 +207,7 @@ export function CartContextProvider(
 		displayPriceString,
 		addUploadedPdf,
 		removeUploadedPdf,
+		persistCart,
 	};
 
 	return <CartContext.Provider value={cartData} {...props} />;

--- a/contexts/CartContext.tsx
+++ b/contexts/CartContext.tsx
@@ -2,8 +2,8 @@ import { createContext, useCallback, useEffect, useRef, useState } from "react";
 import {
 	clearCartPdfs,
 	loadCartPdfs,
-	saveCartPdfs,
 	type StoredPdfItem,
+	saveCartPdfs,
 } from "../lib/cartStorage";
 import { getItemsWithBulkDiscount } from "../lib/utils";
 import type CartItem from "../types/models/CartItem";

--- a/lib/cartStorage.ts
+++ b/lib/cartStorage.ts
@@ -1,0 +1,122 @@
+/**
+ * IndexedDB-based persistence for uploaded PDF files in the cart.
+ *
+ * File objects cannot be serialized to localStorage/sessionStorage, but
+ * IndexedDB supports storing Blobs and Files natively. This module provides
+ * helpers to save and restore PdfCartItem data (including the actual File)
+ * across page navigations — specifically the OAuth redirect flow.
+ */
+
+const DB_NAME = "primal-printing-cart";
+const DB_VERSION = 1;
+const STORE_NAME = "uploaded-pdfs";
+
+/** Serializable representation of a PdfCartItem stored in IndexedDB. */
+export interface StoredPdfItem {
+	id: string;
+	displayName: string;
+	quantity: number;
+	unitPrice: number;
+	priceId: string;
+	pages: number;
+	isColor: boolean;
+	file: File;
+	productId: string;
+}
+
+// ── IndexedDB helpers ────────────────────────────────────────────────────
+
+function openDB(): Promise<IDBDatabase> {
+	return new Promise((resolve, reject) => {
+		const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+		request.onupgradeneeded = () => {
+			const db = request.result;
+			if (!db.objectStoreNames.contains(STORE_NAME)) {
+				db.createObjectStore(STORE_NAME, { keyPath: "id" });
+			}
+		};
+
+		request.onsuccess = () => resolve(request.result);
+		request.onerror = () => reject(request.error);
+	});
+}
+
+/**
+ * Save an array of PDF cart items to IndexedDB.
+ * Replaces any previously stored items.
+ */
+export async function saveCartPdfs(items: StoredPdfItem[]): Promise<void> {
+	const db = await openDB();
+	const tx = db.transaction(STORE_NAME, "readwrite");
+	const store = tx.objectStore(STORE_NAME);
+
+	// Clear existing items first
+	store.clear();
+
+	for (const item of items) {
+		store.put(item);
+	}
+
+	return new Promise((resolve, reject) => {
+		tx.oncomplete = () => {
+			db.close();
+			resolve();
+		};
+		tx.onerror = () => {
+			db.close();
+			reject(tx.error);
+		};
+	});
+}
+
+/**
+ * Load all stored PDF cart items from IndexedDB.
+ * Returns an empty array if nothing is stored or if IndexedDB is unavailable.
+ */
+export async function loadCartPdfs(): Promise<StoredPdfItem[]> {
+	try {
+		const db = await openDB();
+		const tx = db.transaction(STORE_NAME, "readonly");
+		const store = tx.objectStore(STORE_NAME);
+		const request = store.getAll();
+
+		return new Promise((resolve, reject) => {
+			request.onsuccess = () => {
+				db.close();
+				resolve(request.result as StoredPdfItem[]);
+			};
+			request.onerror = () => {
+				db.close();
+				reject(request.error);
+			};
+		});
+	} catch {
+		// IndexedDB may be unavailable (private browsing, etc.)
+		return [];
+	}
+}
+
+/**
+ * Clear all stored PDF cart items from IndexedDB.
+ */
+export async function clearCartPdfs(): Promise<void> {
+	try {
+		const db = await openDB();
+		const tx = db.transaction(STORE_NAME, "readwrite");
+		tx.objectStore(STORE_NAME).clear();
+
+		return new Promise((resolve, reject) => {
+			tx.oncomplete = () => {
+				db.close();
+				resolve();
+			};
+			tx.onerror = () => {
+				db.close();
+				reject(tx.error);
+			};
+		});
+	} catch {
+		// Best effort
+	}
+}

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -158,6 +158,38 @@ export async function sendBankTransferReceivedEmail(params: {
 	});
 }
 
+/**
+ * Send an email notifying the customer that their bank transfer has been
+ * verified and they should now select a pickup timeslot.
+ */
+export async function sendPaymentVerifiedEmail(params: {
+	to: string;
+	customerName: string;
+	orderNumber: string;
+	total: number | undefined;
+	orderUrl?: string;
+}): Promise<void> {
+	const { to, customerName, orderNumber, total, orderUrl } = params;
+
+	const contact = await getContactInfo();
+
+	const html = renderTemplate("paymentVerified", {
+		customerName: customerName || "Customer",
+		orderNumber,
+		total: formatCents(total),
+		orderUrl: orderUrl || "",
+		contactEmail: contact.email,
+		contactPhone: contact.phone,
+	});
+
+	await getTransporter().sendMail({
+		from: `"Primal Printing" <${process.env.GMAIL_USER}>`,
+		to,
+		subject: `Payment Verified — ${orderNumber} — Select Your Pickup Slot`,
+		html,
+	});
+}
+
 // ── Helpers ──────────────────────────────────────────────────────────────
 
 function formatCents(cents: number | undefined | null): string {

--- a/lib/templates/paymentVerified.pug
+++ b/lib/templates/paymentVerified.pug
@@ -1,0 +1,51 @@
+doctype html
+html
+  head
+    meta(charset="utf-8")
+    meta(name="viewport" content="width=device-width, initial-scale=1.0")
+    style.
+      body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; padding: 0; background: #f5f5f5; }
+      .container { max-width: 600px; margin: 0 auto; background: #ffffff; }
+      .header { background: #1a1a2e; color: #ffffff; padding: 32px 24px; text-align: center; }
+      .header h1 { margin: 0; font-size: 24px; font-weight: 600; }
+      .header p { margin: 8px 0 0; opacity: 0.8; font-size: 14px; }
+      .content { padding: 24px; }
+      .status-box { background: #e8f5e9; border-radius: 8px; padding: 16px; border-left: 4px solid #4caf50; margin: 16px 0; }
+      .status-box h3 { margin: 0 0 8px; color: #2e7d32; }
+      .status-box p { margin: 4px 0; }
+      .action-box { background: #e3f2fd; border-radius: 8px; padding: 16px; border-left: 4px solid #1976d2; margin: 16px 0; }
+      .action-box h3 { margin: 0 0 8px; color: #1565c0; }
+      .action-box p { margin: 4px 0; }
+      .cta-button { display: inline-block; background: #1a1a2e; color: #ffffff; text-decoration: none; padding: 12px 32px; border-radius: 6px; font-weight: 600; font-size: 16px; margin: 16px 0; }
+      .footer { padding: 24px; text-align: center; font-size: 13px; color: #999; border-top: 1px solid #eee; }
+  body
+    .container
+      .header
+        h1 Payment Verified ✓
+        p Order ##{orderNumber}
+
+      .content
+        p Hi #{customerName},
+
+        p Great news! Your bank transfer payment for order ##{orderNumber} has been verified.
+
+        .status-box
+          h3 ✅ Payment Confirmed
+          p Your payment of #{total} has been successfully verified by our team.
+
+        .action-box
+          h3 📅 Next Step: Select a Pickup Slot
+          p Your order is ready to be printed — please select a pickup time so we know when to have it ready for you.
+
+        if orderUrl
+          p(style="text-align: center;")
+            a.cta-button(href=orderUrl) Select Pickup Slot
+
+        p If you have any questions about your order, please contact us:
+        if contactEmail
+          p Email: #{contactEmail}
+        if contactPhone
+          p Phone: #{contactPhone}
+
+      .footer
+        p Primal Printing — Thank you for your order!

--- a/pages/auth/callback.tsx
+++ b/pages/auth/callback.tsx
@@ -1,19 +1,18 @@
 import { useEffect } from "react";
 
 /**
- * OAuth callback landing page — used when sign-in opens in a popup.
- * Closes the popup and triggers a session refresh in the parent window.
+ * OAuth callback landing page.
+ *
+ * After Google OAuth completes, NextAuth redirects here. This page reads the
+ * saved return URL from sessionStorage and redirects the user back to where
+ * they were before sign-in (e.g. the order page with their uploaded files
+ * restored from IndexedDB).
  */
 export default function AuthCallback() {
 	useEffect(() => {
-		// Notify the parent window to refresh session
-		if (window.opener) {
-			window.opener.focus();
-			window.close();
-		} else {
-			// Fallback: if not opened as popup, redirect to order page
-			window.location.href = "/order";
-		}
+		const returnUrl = sessionStorage.getItem("auth-return-url") || "/order";
+		sessionStorage.removeItem("auth-return-url");
+		window.location.replace(returnUrl);
 	}, []);
 
 	return (
@@ -27,7 +26,7 @@ export default function AuthCallback() {
 				color: "#666",
 			}}
 		>
-			Signing you in...
+			Signing you in…
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary

Two improvements in this PR:

### 1. Payment Verified Email
When an admin verifies a customer's bank transfer payment, an email is now sent to the customer notifying them that their payment has been verified and prompting them to select a pickup timeslot.

**Files:**
- `lib/templates/paymentVerified.pug` — new styled email template with pickup slot CTA
- `lib/email.ts` — new `sendPaymentVerifiedEmail()` function
- `app/api/shop/[orderId]/approve-payment/route.ts` — sends the email after transitioning to PAID

**Flow:**
```
Admin verifies bank transfer → POST /api/orders/:id/approve-payment
  → Order: PAYMENT_PENDING_VERIFICATION → PAID
  → Files transferred to permanent storage
  → Email sent to customer: "Payment Verified — Select Your Pickup Slot"
```

---

### 2. Fix Mobile Google Sign-In (popup → redirect + IndexedDB)
The popup-based Google OAuth flow (`window.open`) didn't work on mobile — the user would sign in but not be logged into the app after the popup closed, because `window.opener` is unreliable on mobile browsers.

**Fix:** Replaced the popup with a full-page redirect flow on all devices. Uploaded PDF files are persisted to IndexedDB before the redirect and restored when the page reloads after auth.

**Files:**
- `lib/cartStorage.ts` — new IndexedDB helpers to save/load/clear `File` objects
- `contexts/CartContext.tsx` — restores PDFs from IndexedDB on mount, exposes `persistCart()`
- `contexts/AuthContext.tsx` — simplified to always use `signIn('google')` redirect
- `pages/auth/callback.tsx` — simplified to redirect back to saved return URL
- `components/ordercontainer/Cart.tsx` — calls `persistCart()` before `login()`

**How it works:**
```
User uploads PDFs → clicks "Sign in to Order"
  → persistCart() saves File objects to IndexedDB
  → login() saves current URL, redirects to Google OAuth
  → OAuth completes → /auth/callback → redirects back to /order
  → CartContext restores PDFs from IndexedDB → user sees their files
```

Works identically on mobile and desktop.