### PR TITLE
chore: enable React Strict Mode and enforce TypeScript build errors

### DIFF
--- a/app/(payload)/admin/[[...segments]]/not-found.tsx
+++ b/app/(payload)/admin/[[...segments]]/not-found.tsx
@@ -2,7 +2,7 @@
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 
 import { generatePageMetadata, NotFoundPage } from "@payloadcms/next/views";
-import type { AdminViewProps } from "payload";
+
 import config from "@/payload.config";
 import { importMap } from "../importMap";
 
@@ -18,7 +18,7 @@ type Args = {
 export const generateMetadata = ({ params, searchParams }: Args) =>
 	generatePageMetadata({ config, params, searchParams });
 
-const NotFound = ({ params, searchParams }: AdminViewProps) =>
+const NotFound = ({ params, searchParams }: Args) =>
 	NotFoundPage({
 		config,
 		importMap,

--- a/app/(payload)/admin/[[...segments]]/page.tsx
+++ b/app/(payload)/admin/[[...segments]]/page.tsx
@@ -2,7 +2,7 @@
 /* DO NOT MODIFY IT BECAUSE IT COULD BE REWRITTEN AT ANY TIME. */
 
 import { generatePageMetadata, RootPage } from "@payloadcms/next/views";
-import type { AdminViewProps } from "payload";
+
 import config from "@/payload.config";
 import { importMap } from "../importMap";
 
@@ -18,7 +18,7 @@ type Args = {
 export const generateMetadata = ({ params, searchParams }: Args) =>
 	generatePageMetadata({ config, params, searchParams });
 
-const Page = ({ params, searchParams }: AdminViewProps) =>
+const Page = ({ params, searchParams }: Args) =>
 	RootPage({ config, importMap, params, searchParams });
 
 export default Page;

--- a/app/(payload)/api/auth/[...nextauth]/route.ts
+++ b/app/(payload)/api/auth/[...nextauth]/route.ts
@@ -12,7 +12,7 @@ import { getPayloadClient } from "@/lib/payload";
  * Admin users continue to authenticate via the Payload admin panel
  * (separate `users` collection with `auth: true`).
  */
-export const authOptions: NextAuthOptions = {
+const authOptions: NextAuthOptions = {
 	providers: [
 		GoogleProvider({
 			clientId: process.env.GOOGLE_CLIENT_ID || "",
@@ -106,7 +106,7 @@ export const authOptions: NextAuthOptions = {
 				const extendedSession = session as typeof session & {
 					customerId: string;
 				};
-				extendedSession.customerId = token.customerId;
+				extendedSession.customerId = token.customerId as string;
 			}
 			return session;
 		},

--- a/app/api/shop/my-orders/route.ts
+++ b/app/api/shop/my-orders/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server";
+import type { Where } from "payload";
 import { getAuthenticatedCustomer } from "../../../../lib/auth";
 import { getPayloadClient } from "../../../../lib/payload";
 
@@ -30,13 +31,10 @@ export async function GET(request: NextRequest) {
 
 		const payload = await getPayloadClient();
 
-		const where: Record<string, unknown> = {
+		const where: Where = {
 			customer: { equals: customer.customerId },
+			...(statusFilter ? { status: { equals: statusFilter } } : {}),
 		};
-
-		if (statusFilter) {
-			where.status = { equals: statusFilter };
-		}
 
 		const result = await payload.find({
 			collection: "orders",

--- a/collections/Timeslots.ts
+++ b/collections/Timeslots.ts
@@ -45,7 +45,7 @@ export const Timeslots: CollectionConfig = {
 			admin: {
 				description: 'Start time in 24-hour format, e.g. "09:00".',
 			},
-			validate: (value) => {
+			validate: (value: string | null | undefined) => {
 				if (!value) return "Start time is required.";
 				if (!/^\d{2}:\d{2}$/.test(value))
 					return 'Must be in HH:MM format (e.g. "09:00").';
@@ -59,7 +59,7 @@ export const Timeslots: CollectionConfig = {
 			admin: {
 				description: 'End time in 24-hour format, e.g. "17:00".',
 			},
-			validate: (value) => {
+			validate: (value: string | null | undefined) => {
 				if (!value) return "End time is required.";
 				if (!/^\d{2}:\d{2}$/.test(value))
 					return 'Must be in HH:MM format (e.g. "17:00").';

--- a/components/discountbadge/DiscountBadge.tsx
+++ b/components/discountbadge/DiscountBadge.tsx
@@ -9,6 +9,7 @@ export default function DiscountBadge({
 	return (
 		<>
 			{displayCondition && (
+				// @ts-expect-error — Chakra UI v2 Badge props union is too complex for TS 5.x
 				<Badge colorScheme="green">{getPercentOff()}% off!</Badge>
 			)}
 		</>

--- a/contexts/CartContext.tsx
+++ b/contexts/CartContext.tsx
@@ -65,9 +65,7 @@ const alreadyInArray = <T extends CartItem>(
 	return arrayToSearch.some((item) => item.id === itemToCheck.id);
 };
 
-export function CartContextProvider(
-	props: React.PropsWithChildren,
-) {
+export function CartContextProvider(props: React.PropsWithChildren) {
 	const [cartPackages, setCartPackages] = useState<CartItem[]>([]);
 	const [uploadedPdfs, setUploadedPdfs] = useState<PdfCartItem[]>([]);
 	const [displayPriceString, setDisplayPriceString] = useState<string>(

--- a/contexts/CartContext.tsx
+++ b/contexts/CartContext.tsx
@@ -66,7 +66,7 @@ const alreadyInArray = <T extends CartItem>(
 };
 
 export function CartContextProvider(
-	props: React.PropsWithChildren<Record<string, never>>,
+	props: React.PropsWithChildren,
 ) {
 	const [cartPackages, setCartPackages] = useState<CartItem[]>([]);
 	const [uploadedPdfs, setUploadedPdfs] = useState<PdfCartItem[]>([]);

--- a/lib/bankTransfer.ts
+++ b/lib/bankTransfer.ts
@@ -27,7 +27,7 @@ export async function checkBankTransferEligibility(
 	const payload = await getPayloadClient();
 
 	// Find the order by ID or order number
-	let orderDocs: { status?: string; id: string; orderNumber?: string }[];
+	let orderDocs: { status?: string; id: string | number; orderNumber?: string }[];
 
 	if (orderIdentifier.orderId) {
 		try {

--- a/lib/bankTransfer.ts
+++ b/lib/bankTransfer.ts
@@ -27,7 +27,11 @@ export async function checkBankTransferEligibility(
 	const payload = await getPayloadClient();
 
 	// Find the order by ID or order number
-	let orderDocs: { status?: string; id: string | number; orderNumber?: string }[];
+	let orderDocs: {
+		status?: string;
+		id: string | number;
+		orderNumber?: string;
+	}[];
 
 	if (orderIdentifier.orderId) {
 		try {

--- a/lib/r2.ts
+++ b/lib/r2.ts
@@ -125,8 +125,10 @@ export async function countPdfPagesFromStaging(
 			chunks.push(chunk);
 		}
 
-		const pdfParse = (await import("pdf-parse")).default;
-		const parsed = await pdfParse(Buffer.concat(chunks));
+		// Dynamic import – handle CJS/ESM interop at runtime
+		const pdfParseModule = await import("pdf-parse");
+		const pdfParse = (pdfParseModule as { default?: unknown }).default ?? pdfParseModule;
+		const parsed = await (pdfParse as (buf: Buffer) => Promise<{ numpages: number }>)(Buffer.concat(chunks));
 		return parsed.numpages;
 	} catch (err) {
 		console.error("Failed to count pages from staging:", stagingKey, err);
@@ -154,8 +156,9 @@ export async function uploadToStaging(
 	if (contentType === "application/pdf") {
 		try {
 			// Dynamic import to avoid pdf-parse breaking RSC bundling
-			const pdfParse = (await import("pdf-parse")).default;
-			const parsed = await pdfParse(Buffer.from(body));
+			const pdfParseModule = await import("pdf-parse");
+			const pdfParse = (pdfParseModule as { default?: unknown }).default ?? pdfParseModule;
+			const parsed = await (pdfParse as (buf: Buffer) => Promise<{ numpages: number }>)(Buffer.from(body as Uint8Array));
 			pageCount = parsed.numpages;
 		} catch (err) {
 			console.error("Failed to count PDF pages at upload:", err);

--- a/lib/r2.ts
+++ b/lib/r2.ts
@@ -3,7 +3,6 @@ import {
 	CopyObjectCommand,
 	DeleteObjectCommand,
 	GetObjectCommand,
-	HeadObjectCommand,
 	PutObjectCommand,
 	S3Client,
 } from "@aws-sdk/client-s3";
@@ -71,99 +70,17 @@ export function generateProofKey(orderNumber: string): string {
 	return `proofs/${orderNumber}/${randomUUID()}.webp`;
 }
 
-// ── PDF page counting ────────────────────────────────────────────────────
-
-/**
- * Get the verified page count for a staged PDF from R2 metadata.
- * Metadata is set at upload time (inline parsing — file already in memory).
- *
- * Returns null only if the file is inaccessible or metadata wasn't set.
- */
-export async function getVerifiedPageCount(
-	stagingKey: string,
-): Promise<number | null> {
-	const client = getS3Client();
-
-	try {
-		const headResponse = await client.send(
-			new HeadObjectCommand({
-				Bucket: getStagingBucket(),
-				Key: stagingKey,
-			}),
-		);
-		const pageCountStr = headResponse.Metadata?.["page-count"];
-		if (pageCountStr) {
-			const parsed = Number.parseInt(pageCountStr, 10);
-			if (!Number.isNaN(parsed) && parsed > 0) return parsed;
-		}
-	} catch (err) {
-		console.error("HeadObject failed for", stagingKey, err);
-	}
-
-	return null;
-}
-
-/**
- * Download a PDF from staging and count its pages directly.
- * Used as a fallback when metadata is not available.
- */
-export async function countPdfPagesFromStaging(
-	stagingKey: string,
-): Promise<number | null> {
-	const client = getS3Client();
-	try {
-		const response = await client.send(
-			new GetObjectCommand({
-				Bucket: getStagingBucket(),
-				Key: stagingKey,
-			}),
-		);
-
-		const chunks: Uint8Array[] = [];
-		const stream = response.Body as AsyncIterable<Uint8Array>;
-		for await (const chunk of stream) {
-			chunks.push(chunk);
-		}
-
-		// Dynamic import – handle CJS/ESM interop at runtime
-		const pdfParseModule = await import("pdf-parse");
-		const pdfParse = (pdfParseModule as { default?: unknown }).default ?? pdfParseModule;
-		const parsed = await (pdfParse as (buf: Buffer) => Promise<{ numpages: number }>)(Buffer.concat(chunks));
-		return parsed.numpages;
-	} catch (err) {
-		console.error("Failed to count pages from staging:", stagingKey, err);
-		return null;
-	}
-}
-
 // ── Upload operations ────────────────────────────────────────────────────
 
 /**
  * Upload a file buffer to the staging R2 bucket.
- * If the file is a PDF, pages are counted inline (file is already in memory
- * from the upload — negligible cost) and stored as R2 custom metadata.
  */
 export async function uploadToStaging(
 	key: string,
 	body: Buffer | Uint8Array,
 	contentType: string,
-): Promise<{ pageCount?: number }> {
+): Promise<void> {
 	const client = getS3Client();
-
-	let pageCount: number | undefined;
-
-	// Count pages inline — file is already in memory from the upload
-	if (contentType === "application/pdf") {
-		try {
-			// Dynamic import to avoid pdf-parse breaking RSC bundling
-			const pdfParseModule = await import("pdf-parse");
-			const pdfParse = (pdfParseModule as { default?: unknown }).default ?? pdfParseModule;
-			const parsed = await (pdfParse as (buf: Buffer) => Promise<{ numpages: number }>)(Buffer.from(body as Uint8Array));
-			pageCount = parsed.numpages;
-		} catch (err) {
-			console.error("Failed to count PDF pages at upload:", err);
-		}
-	}
 
 	await client.send(
 		new PutObjectCommand({
@@ -171,11 +88,8 @@ export async function uploadToStaging(
 			Key: key,
 			Body: body,
 			ContentType: contentType,
-			Metadata: pageCount ? { "page-count": String(pageCount) } : undefined,
 		}),
 	);
-
-	return { pageCount };
 }
 
 /**

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -7,7 +7,9 @@ export const guidGenerator = () => {
 	return S4() + S4();
 };
 
-export const formatItems = (items: { name: string; quantity: number; cost: number }[]): string => {
+export const formatItems = (
+	items: { name: string; quantity: number; cost: number }[],
+): string => {
 	const listItems = items.map((item) => {
 		return `<li>${item.name} - Qty: ${item.quantity}, Cost: ${item.cost}</li>`;
 	});

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -7,7 +7,7 @@ export const guidGenerator = () => {
 	return S4() + S4();
 };
 
-export const formatItems = (items): string => {
+export const formatItems = (items: { name: string; quantity: number; cost: number }[]): string => {
 	const listItems = items.map((item) => {
 		return `<li>${item.name} - Qty: ${item.quantity}, Cost: ${item.cost}</li>`;
 	});
@@ -17,7 +17,7 @@ export const formatItems = (items): string => {
 	return formattedString;
 };
 
-export const orderSum = (orderItems) => {
+export const orderSum = (orderItems: { cost: number }[]) => {
 	let sum = 0;
 	orderItems.map((item) => {
 		sum += item.cost;

--- a/next.config.js
+++ b/next.config.js
@@ -2,9 +2,9 @@ const { withPayload } = require("@payloadcms/next/withPayload");
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-	reactStrictMode: false,
+	reactStrictMode: true,
 	typescript: {
-		ignoreBuildErrors: true,
+		ignoreBuildErrors: false,
 	},
 };
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
 		"nextjs-google-analytics": "^2.3.3",
 		"nodemailer": "^7.0.5",
 		"payload": "^3.82.1",
-		"pdf-parse": "^2.4.5",
 		"pdfjs-dist": "^3.5.141",
 		"pug": "^3.0.3",
 		"react": "19.2.5",
@@ -53,7 +52,6 @@
 	"devDependencies": {
 		"@biomejs/biome": "2.1.1",
 		"@types/node": "18.6.2",
-		"@types/pdf-parse": "^1.1.5",
 		"@types/react": "19.2.14",
 		"@types/react-dom": "19.2.3",
 		"dotenv": "^17.4.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"@payloadcms/next": "^3.82.1",
 		"@payloadcms/richtext-lexical": "^3.82.1",
 		"@payloadcms/storage-s3": "^3.82.1",
+		"@payloadcms/ui": "^3.82.1",
 		"@stripe/react-stripe-js": "^6.2.0",
 		"@stripe/stripe-js": "^9.2.0",
 		"@types/nodemailer": "^6.4.17",
@@ -31,6 +32,7 @@
 		"framer-motion": "^6.5.1",
 		"googleapis": "^118.0.0",
 		"graphql": "^16.13.2",
+		"lexical": "^0.43.0",
 		"multer": "^1.4.5-lts.1",
 		"next": "15.5.15",
 		"next-auth": "^4.24.14",
@@ -57,7 +59,7 @@
 		"dotenv": "^17.4.2",
 		"eslint-config-next": "15.5.15",
 		"lefthook": "^1.12.2",
-		"typescript": "4.7.4"
+		"typescript": "5.8.3"
 	},
 	"engines": {
 		"node": ">=20",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -158,7 +158,7 @@ By Students, For Students🚀💯"
 									{section.content && (
 										<RichText
 											data={
-												section.content as import("lexical").SerializedEditorState
+												section.content as unknown as import("lexical").SerializedEditorState
 											}
 										/>
 									)}

--- a/pages/order.tsx
+++ b/pages/order.tsx
@@ -11,7 +11,7 @@ export async function getStaticProps() {
 		revalidate: 60 * 60,
 	};
 }
-const Order: NextPage = ({ packages }) => {
+const Order: NextPage = () => {
 	return (
 		<>
 			<Head>
@@ -30,7 +30,7 @@ const Order: NextPage = ({ packages }) => {
 			</Head>
 			<Box className="container">
 				<NavBar />
-				<OrderContainer packages={packages.data} />
+				<OrderContainer />
 			</Box>
 		</>
 	);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,16 +31,19 @@ importers:
         version: 11.9.3(@babel/core@7.18.9)(@emotion/react@11.9.3(@babel/core@7.18.9)(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5)
       '@payloadcms/db-mongodb':
         specifier: ^3.82.1
-        version: 3.82.1(gcp-metadata@5.2.0)(payload@3.82.1(graphql@16.13.2)(typescript@4.7.4))
+        version: 3.82.1(gcp-metadata@5.2.0)(payload@3.82.1(graphql@16.13.2)(typescript@5.8.3))
       '@payloadcms/next':
         specifier: ^3.82.1
-        version: 3.82.1(@babel/core@7.18.9)(@types/react@19.2.14)(graphql@16.13.2)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@4.7.4))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@4.7.4)
+        version: 3.82.1(@babel/core@7.18.9)(@types/react@19.2.14)(graphql@16.13.2)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@5.8.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.8.3)
       '@payloadcms/richtext-lexical':
         specifier: ^3.82.1
-        version: 3.82.1(@babel/core@7.18.9)(@faceless-ui/modal@3.0.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@faceless-ui/scroll-info@2.0.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@payloadcms/next@3.82.1(@babel/core@7.18.9)(@types/react@19.2.14)(graphql@16.13.2)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@4.7.4))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@4.7.4))(@types/react@19.2.14)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@4.7.4))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@4.7.4)(yjs@13.6.30)
+        version: 3.82.1(@babel/core@7.18.9)(@faceless-ui/modal@3.0.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@faceless-ui/scroll-info@2.0.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@payloadcms/next@3.82.1(@babel/core@7.18.9)(@types/react@19.2.14)(graphql@16.13.2)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@5.8.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.8.3))(@types/react@19.2.14)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@5.8.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.8.3)(yjs@13.6.30)
       '@payloadcms/storage-s3':
         specifier: ^3.82.1
-        version: 3.82.1(@babel/core@7.18.9)(@types/react@19.2.14)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@4.7.4))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@4.7.4)
+        version: 3.82.1(@babel/core@7.18.9)(@types/react@19.2.14)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@5.8.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.8.3)
+      '@payloadcms/ui':
+        specifier: ^3.82.1
+        version: 3.82.1(@babel/core@7.18.9)(@types/react@19.2.14)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@5.8.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.8.3)
       '@stripe/react-stripe-js':
         specifier: ^6.2.0
         version: 6.2.0(@stripe/stripe-js@9.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -68,6 +71,9 @@ importers:
       graphql:
         specifier: ^16.13.2
         version: 16.13.2
+      lexical:
+        specifier: ^0.43.0
+        version: 0.43.0
       multer:
         specifier: ^1.4.5-lts.1
         version: 1.4.5-lts.1
@@ -85,7 +91,7 @@ importers:
         version: 7.0.5
       payload:
         specifier: ^3.82.1
-        version: 3.82.1(graphql@16.13.2)(typescript@4.7.4)
+        version: 3.82.1(graphql@16.13.2)(typescript@5.8.3)
       pdf-parse:
         specifier: ^2.4.5
         version: 2.4.5
@@ -137,13 +143,13 @@ importers:
         version: 17.4.2
       eslint-config-next:
         specifier: 15.5.15
-        version: 15.5.15(eslint@8.20.0)(typescript@4.7.4)
+        version: 15.5.15(eslint@8.20.0)(typescript@5.8.3)
       lefthook:
         specifier: ^1.12.2
         version: 1.12.2
       typescript:
-        specifier: 4.7.4
-        version: 4.7.4
+        specifier: 5.8.3
+        version: 5.8.3
 
 packages:
 
@@ -4079,6 +4085,9 @@ packages:
   lexical@0.41.0:
     resolution: {integrity: sha512-pNIm5+n+hVnJHB9gYPDYsIO5Y59dNaDU9rJmPPsfqQhP2ojKFnUoPbcRnrI9FJLXB14sSumcY8LUw7Sq70TZqA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/lexical/-/lexical-0.41.0.tgz}
 
+  lexical@0.43.0:
+    resolution: {integrity: sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/lexical/-/lexical-0.43.0.tgz}
+
   lib0@0.2.117:
     resolution: {integrity: sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/lib0/-/lib0-0.2.117.tgz}
     engines: {node: '>=16'}
@@ -5315,9 +5324,9 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/typedarray/-/typedarray-0.0.6.tgz}
 
-  typescript@4.7.4:
-    resolution: {integrity: sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/typescript/-/typescript-4.7.4.tgz}
-    engines: {node: '>=4.2.0'}
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/typescript/-/typescript-5.8.3.tgz}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   uint8array-extras@1.5.0:
@@ -6771,7 +6780,7 @@ snapshots:
   '@dnd-kit/accessibility@3.1.1(react@19.2.5)':
     dependencies:
       react: 19.2.5
-      tslib: 2.4.0
+      tslib: 2.8.1
 
   '@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
@@ -6779,7 +6788,7 @@ snapshots:
       '@dnd-kit/utilities': 3.2.2(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      tslib: 2.4.0
+      tslib: 2.8.1
 
   '@dnd-kit/modifiers@9.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
     dependencies:
@@ -6793,12 +6802,12 @@ snapshots:
       '@dnd-kit/core': 6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@dnd-kit/utilities': 3.2.2(react@19.2.5)
       react: 19.2.5
-      tslib: 2.4.0
+      tslib: 2.8.1
 
   '@dnd-kit/utilities@3.2.2(react@19.2.5)':
     dependencies:
       react: 19.2.5
-      tslib: 2.4.0
+      tslib: 2.8.1
 
   '@emnapi/core@1.9.2':
     dependencies:
@@ -7912,11 +7921,11 @@ snapshots:
 
   '@panva/hkdf@1.2.1': {}
 
-  '@payloadcms/db-mongodb@3.82.1(gcp-metadata@5.2.0)(payload@3.82.1(graphql@16.13.2)(typescript@4.7.4))':
+  '@payloadcms/db-mongodb@3.82.1(gcp-metadata@5.2.0)(payload@3.82.1(graphql@16.13.2)(typescript@5.8.3))':
     dependencies:
       mongoose: 8.15.1(gcp-metadata@5.2.0)
       mongoose-paginate-v2: 1.9.4(mongoose@8.15.1(gcp-metadata@5.2.0))
-      payload: 3.82.1(graphql@16.13.2)(typescript@4.7.4)
+      payload: 3.82.1(graphql@16.13.2)(typescript@5.8.3)
       prompts: 2.4.2
       uuid: 10.0.0
     transitivePeerDependencies:
@@ -7929,25 +7938,25 @@ snapshots:
       - socks
       - supports-color
 
-  '@payloadcms/graphql@3.82.1(graphql@16.13.2)(payload@3.82.1(graphql@16.13.2)(typescript@4.7.4))(typescript@4.7.4)':
+  '@payloadcms/graphql@3.82.1(graphql@16.13.2)(payload@3.82.1(graphql@16.13.2)(typescript@5.8.3))(typescript@5.8.3)':
     dependencies:
       graphql: 16.13.2
       graphql-scalars: 1.22.2(graphql@16.13.2)
-      payload: 3.82.1(graphql@16.13.2)(typescript@4.7.4)
+      payload: 3.82.1(graphql@16.13.2)(typescript@5.8.3)
       pluralize: 8.0.0
-      ts-essentials: 10.0.3(typescript@4.7.4)
+      ts-essentials: 10.0.3(typescript@5.8.3)
       tsx: 4.21.0
     transitivePeerDependencies:
       - typescript
 
-  '@payloadcms/next@3.82.1(@babel/core@7.18.9)(@types/react@19.2.14)(graphql@16.13.2)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@4.7.4))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@4.7.4)':
+  '@payloadcms/next@3.82.1(@babel/core@7.18.9)(@types/react@19.2.14)(graphql@16.13.2)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@5.8.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.8.3)':
     dependencies:
       '@dnd-kit/core': 6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@dnd-kit/modifiers': 9.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       '@dnd-kit/sortable': 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
-      '@payloadcms/graphql': 3.82.1(graphql@16.13.2)(payload@3.82.1(graphql@16.13.2)(typescript@4.7.4))(typescript@4.7.4)
+      '@payloadcms/graphql': 3.82.1(graphql@16.13.2)(payload@3.82.1(graphql@16.13.2)(typescript@5.8.3))(typescript@5.8.3)
       '@payloadcms/translations': 3.82.1
-      '@payloadcms/ui': 3.82.1(@babel/core@7.18.9)(@types/react@19.2.14)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@4.7.4))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@4.7.4)
+      '@payloadcms/ui': 3.82.1(@babel/core@7.18.9)(@types/react@19.2.14)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@5.8.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.8.3)
       busboy: 1.6.0
       dequal: 2.0.3
       file-type: 21.3.4
@@ -7957,7 +7966,7 @@ snapshots:
       http-status: 2.1.0
       next: 15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4)
       path-to-regexp: 6.3.0
-      payload: 3.82.1(graphql@16.13.2)(typescript@4.7.4)
+      payload: 3.82.1(graphql@16.13.2)(typescript@5.8.3)
       qs-esm: 8.0.1
       sass: 1.77.4
       uuid: 10.0.0
@@ -7970,11 +7979,11 @@ snapshots:
       - supports-color
       - typescript
 
-  '@payloadcms/plugin-cloud-storage@3.82.1(@babel/core@7.18.9)(@types/react@19.2.14)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@4.7.4))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@4.7.4)':
+  '@payloadcms/plugin-cloud-storage@3.82.1(@babel/core@7.18.9)(@types/react@19.2.14)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@5.8.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.8.3)':
     dependencies:
-      '@payloadcms/ui': 3.82.1(@babel/core@7.18.9)(@types/react@19.2.14)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@4.7.4))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@4.7.4)
+      '@payloadcms/ui': 3.82.1(@babel/core@7.18.9)(@types/react@19.2.14)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@5.8.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.8.3)
       find-node-modules: 2.1.3
-      payload: 3.82.1(graphql@16.13.2)(typescript@4.7.4)
+      payload: 3.82.1(graphql@16.13.2)(typescript@5.8.3)
       range-parser: 1.2.1
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -7985,7 +7994,7 @@ snapshots:
       - next
       - typescript
 
-  '@payloadcms/richtext-lexical@3.82.1(@babel/core@7.18.9)(@faceless-ui/modal@3.0.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@faceless-ui/scroll-info@2.0.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@payloadcms/next@3.82.1(@babel/core@7.18.9)(@types/react@19.2.14)(graphql@16.13.2)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@4.7.4))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@4.7.4))(@types/react@19.2.14)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@4.7.4))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@4.7.4)(yjs@13.6.30)':
+  '@payloadcms/richtext-lexical@3.82.1(@babel/core@7.18.9)(@faceless-ui/modal@3.0.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@faceless-ui/scroll-info@2.0.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@payloadcms/next@3.82.1(@babel/core@7.18.9)(@types/react@19.2.14)(graphql@16.13.2)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@5.8.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.8.3))(@types/react@19.2.14)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@5.8.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.8.3)(yjs@13.6.30)':
     dependencies:
       '@faceless-ui/modal': 3.0.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@faceless-ui/scroll-info': 2.0.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -8000,9 +8009,9 @@ snapshots:
       '@lexical/selection': 0.41.0
       '@lexical/table': 0.41.0
       '@lexical/utils': 0.41.0
-      '@payloadcms/next': 3.82.1(@babel/core@7.18.9)(@types/react@19.2.14)(graphql@16.13.2)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@4.7.4))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@4.7.4)
+      '@payloadcms/next': 3.82.1(@babel/core@7.18.9)(@types/react@19.2.14)(graphql@16.13.2)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@5.8.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.8.3)
       '@payloadcms/translations': 3.82.1
-      '@payloadcms/ui': 3.82.1(@babel/core@7.18.9)(@types/react@19.2.14)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@4.7.4))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@4.7.4)
+      '@payloadcms/ui': 3.82.1(@babel/core@7.18.9)(@types/react@19.2.14)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@5.8.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.8.3)
       '@types/uuid': 10.0.0
       acorn: 8.16.0
       bson-objectid: 2.0.4
@@ -8014,12 +8023,12 @@ snapshots:
       mdast-util-from-markdown: 2.0.2
       mdast-util-mdx-jsx: 3.1.3
       micromark-extension-mdx-jsx: 3.0.1
-      payload: 3.82.1(graphql@16.13.2)(typescript@4.7.4)
+      payload: 3.82.1(graphql@16.13.2)(typescript@5.8.3)
       qs-esm: 8.0.1
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       react-error-boundary: 4.1.2(react@19.2.5)
-      ts-essentials: 10.0.3(typescript@4.7.4)
+      ts-essentials: 10.0.3(typescript@5.8.3)
       uuid: 10.0.0
     transitivePeerDependencies:
       - '@babel/core'
@@ -8032,13 +8041,13 @@ snapshots:
       - utf-8-validate
       - yjs
 
-  '@payloadcms/storage-s3@3.82.1(@babel/core@7.18.9)(@types/react@19.2.14)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@4.7.4))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@4.7.4)':
+  '@payloadcms/storage-s3@3.82.1(@babel/core@7.18.9)(@types/react@19.2.14)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@5.8.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.8.3)':
     dependencies:
       '@aws-sdk/client-s3': 3.1030.0
       '@aws-sdk/lib-storage': 3.1030.0(@aws-sdk/client-s3@3.1030.0)
       '@aws-sdk/s3-request-presigner': 3.1030.0
-      '@payloadcms/plugin-cloud-storage': 3.82.1(@babel/core@7.18.9)(@types/react@19.2.14)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@4.7.4))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@4.7.4)
-      payload: 3.82.1(graphql@16.13.2)(typescript@4.7.4)
+      '@payloadcms/plugin-cloud-storage': 3.82.1(@babel/core@7.18.9)(@types/react@19.2.14)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@5.8.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.8.3)
+      payload: 3.82.1(graphql@16.13.2)(typescript@5.8.3)
     transitivePeerDependencies:
       - '@babel/core'
       - '@types/react'
@@ -8053,7 +8062,7 @@ snapshots:
     dependencies:
       date-fns: 4.1.0
 
-  '@payloadcms/ui@3.82.1(@babel/core@7.18.9)(@types/react@19.2.14)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@4.7.4))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@4.7.4)':
+  '@payloadcms/ui@3.82.1(@babel/core@7.18.9)(@types/react@19.2.14)(monaco-editor@0.55.1)(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@5.8.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.8.3)':
     dependencies:
       '@date-fns/tz': 1.2.0
       '@dnd-kit/core': 6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -8070,7 +8079,7 @@ snapshots:
       md5: 2.3.0
       next: 15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4)
       object-to-formdata: 4.5.1
-      payload: 3.82.1(graphql@16.13.2)(typescript@4.7.4)
+      payload: 3.82.1(graphql@16.13.2)(typescript@5.8.3)
       qs-esm: 8.0.1
       react: 19.2.5
       react-datepicker: 7.6.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -8079,7 +8088,7 @@ snapshots:
       react-select: 5.9.0(@babel/core@7.18.9)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       scheduler: 0.25.0
       sonner: 1.7.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      ts-essentials: 10.0.3(typescript@4.7.4)
+      ts-essentials: 10.0.3(typescript@5.8.3)
       use-context-selector: 2.0.0(react@19.2.5)(scheduler@0.25.0)
       uuid: 10.0.0
     transitivePeerDependencies:
@@ -8584,40 +8593,40 @@ snapshots:
     dependencies:
       '@types/node': 18.6.2
 
-  '@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@5.31.0(eslint@8.20.0)(typescript@4.7.4))(eslint@8.20.0)(typescript@4.7.4)':
+  '@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@5.31.0(eslint@8.20.0)(typescript@5.8.3))(eslint@8.20.0)(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 5.31.0(eslint@8.20.0)(typescript@4.7.4)
+      '@typescript-eslint/parser': 5.31.0(eslint@8.20.0)(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 8.58.2
-      '@typescript-eslint/type-utils': 8.58.2(eslint@8.20.0)(typescript@4.7.4)
-      '@typescript-eslint/utils': 8.58.2(eslint@8.20.0)(typescript@4.7.4)
+      '@typescript-eslint/type-utils': 8.58.2(eslint@8.20.0)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.58.2(eslint@8.20.0)(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.58.2
       eslint: 8.20.0
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@4.7.4)
-      typescript: 4.7.4
+      ts-api-utils: 2.5.0(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@5.31.0(eslint@8.20.0)(typescript@4.7.4)':
+  '@typescript-eslint/parser@5.31.0(eslint@8.20.0)(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.31.0
       '@typescript-eslint/types': 5.31.0
-      '@typescript-eslint/typescript-estree': 5.31.0(typescript@4.7.4)
+      '@typescript-eslint/typescript-estree': 5.31.0(typescript@5.8.3)
       debug: 4.4.3
       eslint: 8.20.0
     optionalDependencies:
-      typescript: 4.7.4
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.58.2(typescript@4.7.4)':
+  '@typescript-eslint/project-service@8.58.2(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@4.7.4)
+      '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@5.8.3)
       '@typescript-eslint/types': 8.58.2
       debug: 4.4.3
-      typescript: 4.7.4
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8631,19 +8640,19 @@ snapshots:
       '@typescript-eslint/types': 8.58.2
       '@typescript-eslint/visitor-keys': 8.58.2
 
-  '@typescript-eslint/tsconfig-utils@8.58.2(typescript@4.7.4)':
+  '@typescript-eslint/tsconfig-utils@8.58.2(typescript@5.8.3)':
     dependencies:
-      typescript: 4.7.4
+      typescript: 5.8.3
 
-  '@typescript-eslint/type-utils@8.58.2(eslint@8.20.0)(typescript@4.7.4)':
+  '@typescript-eslint/type-utils@8.58.2(eslint@8.20.0)(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/types': 8.58.2
-      '@typescript-eslint/typescript-estree': 8.58.2(typescript@4.7.4)
-      '@typescript-eslint/utils': 8.58.2(eslint@8.20.0)(typescript@4.7.4)
+      '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.58.2(eslint@8.20.0)(typescript@5.8.3)
       debug: 4.4.3
       eslint: 8.20.0
-      ts-api-utils: 2.5.0(typescript@4.7.4)
-      typescript: 4.7.4
+      ts-api-utils: 2.5.0(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8651,7 +8660,7 @@ snapshots:
 
   '@typescript-eslint/types@8.58.2': {}
 
-  '@typescript-eslint/typescript-estree@5.31.0(typescript@4.7.4)':
+  '@typescript-eslint/typescript-estree@5.31.0(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/types': 5.31.0
       '@typescript-eslint/visitor-keys': 5.31.0
@@ -8659,35 +8668,35 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.4
-      tsutils: 3.21.0(typescript@4.7.4)
+      tsutils: 3.21.0(typescript@5.8.3)
     optionalDependencies:
-      typescript: 4.7.4
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.58.2(typescript@4.7.4)':
+  '@typescript-eslint/typescript-estree@8.58.2(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.58.2(typescript@4.7.4)
-      '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@4.7.4)
+      '@typescript-eslint/project-service': 8.58.2(typescript@5.8.3)
+      '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@5.8.3)
       '@typescript-eslint/types': 8.58.2
       '@typescript-eslint/visitor-keys': 8.58.2
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.4
       tinyglobby: 0.2.16
-      ts-api-utils: 2.5.0(typescript@4.7.4)
-      typescript: 4.7.4
+      ts-api-utils: 2.5.0(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.58.2(eslint@8.20.0)(typescript@4.7.4)':
+  '@typescript-eslint/utils@8.58.2(eslint@8.20.0)(typescript@5.8.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@8.20.0)
       '@typescript-eslint/scope-manager': 8.58.2
       '@typescript-eslint/types': 8.58.2
-      '@typescript-eslint/typescript-estree': 8.58.2(typescript@4.7.4)
+      '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.8.3)
       eslint: 8.20.0
-      typescript: 4.7.4
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -9264,8 +9273,8 @@ snapshots:
 
   dom-helpers@5.2.1:
     dependencies:
-      '@babel/runtime': 7.18.9
-      csstype: 3.1.0
+      '@babel/runtime': 7.29.2
+      csstype: 3.2.3
 
   dompurify@3.2.7:
     optionalDependencies:
@@ -9500,21 +9509,21 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@15.5.15(eslint@8.20.0)(typescript@4.7.4):
+  eslint-config-next@15.5.15(eslint@8.20.0)(typescript@5.8.3):
     dependencies:
       '@next/eslint-plugin-next': 15.5.15
       '@rushstack/eslint-patch': 1.16.1
-      '@typescript-eslint/eslint-plugin': 8.58.2(@typescript-eslint/parser@5.31.0(eslint@8.20.0)(typescript@4.7.4))(eslint@8.20.0)(typescript@4.7.4)
-      '@typescript-eslint/parser': 5.31.0(eslint@8.20.0)(typescript@4.7.4)
+      '@typescript-eslint/eslint-plugin': 8.58.2(@typescript-eslint/parser@5.31.0(eslint@8.20.0)(typescript@5.8.3))(eslint@8.20.0)(typescript@5.8.3)
+      '@typescript-eslint/parser': 5.31.0(eslint@8.20.0)(typescript@5.8.3)
       eslint: 8.20.0
       eslint-import-resolver-node: 0.3.6
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.20.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.31.0(eslint@8.20.0)(typescript@4.7.4))(eslint-import-resolver-typescript@3.10.1)(eslint@8.20.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.31.0(eslint@8.20.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.20.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.20.0)
       eslint-plugin-react: 7.37.5(eslint@8.20.0)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.20.0)
     optionalDependencies:
-      typescript: 4.7.4
+      typescript: 5.8.3
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - eslint-plugin-import-x
@@ -9546,22 +9555,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.31.0(eslint@8.20.0)(typescript@4.7.4))(eslint-import-resolver-typescript@3.10.1)(eslint@8.20.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.31.0(eslint@8.20.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.20.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.31.0(eslint@8.20.0)(typescript@4.7.4))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.20.0):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.31.0(eslint@8.20.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.20.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 5.31.0(eslint@8.20.0)(typescript@4.7.4)
+      '@typescript-eslint/parser': 5.31.0(eslint@8.20.0)(typescript@5.8.3)
       eslint: 8.20.0
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.20.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.31.0(eslint@8.20.0)(typescript@4.7.4))(eslint-import-resolver-typescript@3.10.1)(eslint@8.20.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.31.0(eslint@8.20.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.20.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -9572,7 +9581,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.20.0
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.31.0(eslint@8.20.0)(typescript@4.7.4))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.20.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.31.0(eslint@8.20.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.20.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -9584,7 +9593,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 5.31.0(eslint@8.20.0)(typescript@4.7.4)
+      '@typescript-eslint/parser': 5.31.0(eslint@8.20.0)(typescript@5.8.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -10589,6 +10598,8 @@ snapshots:
 
   lexical@0.41.0: {}
 
+  lexical@0.43.0: {}
+
   lib0@0.2.117:
     dependencies:
       isomorphic.js: 0.2.5
@@ -11206,7 +11217,7 @@ snapshots:
 
   path2d-polyfill@2.0.1: {}
 
-  payload@3.82.1(graphql@16.13.2)(typescript@4.7.4):
+  payload@3.82.1(graphql@16.13.2)(typescript@5.8.3):
     dependencies:
       '@next/env': 15.5.15
       '@payloadcms/translations': 3.82.1
@@ -11235,7 +11246,7 @@ snapshots:
       qs-esm: 8.0.1
       range-parser: 1.2.1
       sanitize-filename: 1.6.3
-      ts-essentials: 10.0.3(typescript@4.7.4)
+      ts-essentials: 10.0.3(typescript@5.8.3)
       tsx: 4.21.0
       undici: 7.24.4
       uuid: 10.0.0
@@ -11553,7 +11564,7 @@ snapshots:
 
   react-select@5.9.0(@babel/core@7.18.9)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.29.2
       '@emotion/cache': 11.9.3
       '@emotion/react': 11.9.3(@babel/core@7.18.9)(@types/react@19.2.14)(react@19.2.5)
       '@floating-ui/dom': 1.7.6
@@ -11579,7 +11590,7 @@ snapshots:
 
   react-transition-group@4.4.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.29.2
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -12060,13 +12071,13 @@ snapshots:
     dependencies:
       utf8-byte-length: 1.0.5
 
-  ts-api-utils@2.5.0(typescript@4.7.4):
+  ts-api-utils@2.5.0(typescript@5.8.3):
     dependencies:
-      typescript: 4.7.4
+      typescript: 5.8.3
 
-  ts-essentials@10.0.3(typescript@4.7.4):
+  ts-essentials@10.0.3(typescript@5.8.3):
     optionalDependencies:
-      typescript: 4.7.4
+      typescript: 5.8.3
 
   tsconfig-paths@3.15.0:
     dependencies:
@@ -12081,10 +12092,10 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsutils@3.21.0(typescript@4.7.4):
+  tsutils@3.21.0(typescript@5.8.3):
     dependencies:
       tslib: 1.14.1
-      typescript: 4.7.4
+      typescript: 5.8.3
 
   tsx@4.20.3:
     dependencies:
@@ -12146,7 +12157,7 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript@4.7.4: {}
+  typescript@5.8.3: {}
 
   uint8array-extras@1.5.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,9 +92,6 @@ importers:
       payload:
         specifier: ^3.82.1
         version: 3.82.1(graphql@16.13.2)(typescript@5.8.3)
-      pdf-parse:
-        specifier: ^2.4.5
-        version: 2.4.5
       pdfjs-dist:
         specifier: ^3.5.141
         version: 3.5.141
@@ -129,9 +126,6 @@ importers:
       '@types/node':
         specifier: 18.6.2
         version: 18.6.2
-      '@types/pdf-parse':
-        specifier: ^1.1.5
-        version: 1.1.5
       '@types/react':
         specifier: 19.2.14
         version: 19.2.14
@@ -1804,70 +1798,6 @@ packages:
   '@motionone/utils@10.13.1':
     resolution: {integrity: sha512-TjDPTIppaf3ofBXQv4ZzAketJgN0sclALXfZ6mfrkjJkOy83mLls9744F+6S+VKCpBmvbZcBY4PQfrfhAfeMtA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@motionone/utils/-/utils-10.13.1.tgz}
 
-  '@napi-rs/canvas-android-arm64@0.1.80':
-    resolution: {integrity: sha512-sk7xhN/MoXeuExlggf91pNziBxLPVUqF2CAVnB57KLG/pz7+U5TKG8eXdc3pm0d7Od0WreB6ZKLj37sX9muGOQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.80.tgz}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [android]
-
-  '@napi-rs/canvas-darwin-arm64@0.1.80':
-    resolution: {integrity: sha512-O64APRTXRUiAz0P8gErkfEr3lipLJgM6pjATwavZ22ebhjYl/SUbpgM0xcWPQBNMP1n29afAC/Us5PX1vg+JNQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.80.tgz}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@napi-rs/canvas-darwin-x64@0.1.80':
-    resolution: {integrity: sha512-FqqSU7qFce0Cp3pwnTjVkKjjOtxMqRe6lmINxpIZYaZNnVI0H5FtsaraZJ36SiTHNjZlUB69/HhxNDT1Aaa9vA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.80.tgz}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.80':
-    resolution: {integrity: sha512-eyWz0ddBDQc7/JbAtY4OtZ5SpK8tR4JsCYEZjCE3dI8pqoWUC8oMwYSBGCYfsx2w47cQgQCgMVRVTFiiO38hHQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.80.tgz}
-    engines: {node: '>= 10'}
-    cpu: [arm]
-    os: [linux]
-
-  '@napi-rs/canvas-linux-arm64-gnu@0.1.80':
-    resolution: {integrity: sha512-qwA63t8A86bnxhuA/GwOkK3jvb+XTQaTiVML0vAWoHyoZYTjNs7BzoOONDgTnNtr8/yHrq64XXzUoLqDzU+Uuw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.80.tgz}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@napi-rs/canvas-linux-arm64-musl@0.1.80':
-    resolution: {integrity: sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.80.tgz}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@napi-rs/canvas-linux-riscv64-gnu@0.1.80':
-    resolution: {integrity: sha512-XTzR125w5ZMs0lJcxRlS1K3P5RaZ9RmUsPtd1uGt+EfDyYMu4c6SEROYsxyatbbu/2+lPe7MPHOO/0a0x7L/gw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.80.tgz}
-    engines: {node: '>= 10'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@napi-rs/canvas-linux-x64-gnu@0.1.80':
-    resolution: {integrity: sha512-BeXAmhKg1kX3UCrJsYbdQd3hIMDH/K6HnP/pG2LuITaXhXBiNdh//TVVVVCBbJzVQaV5gK/4ZOCMrQW9mvuTqA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.80.tgz}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
-  '@napi-rs/canvas-linux-x64-musl@0.1.80':
-    resolution: {integrity: sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.80.tgz}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
-  '@napi-rs/canvas-win32-x64-msvc@0.1.80':
-    resolution: {integrity: sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.80.tgz}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@napi-rs/canvas@0.1.80':
-    resolution: {integrity: sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@napi-rs/canvas/-/canvas-0.1.80.tgz}
-    engines: {node: '>= 10'}
-
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz}
 
@@ -2334,9 +2264,6 @@ packages:
 
   '@types/parse-json@4.0.0':
     resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@types/parse-json/-/parse-json-4.0.0.tgz}
-
-  '@types/pdf-parse@1.1.5':
-    resolution: {integrity: sha512-kBfrSXsloMnUJOKi25s3+hRmkycHfLK6A09eRGqF/N8BkQoPUmaCr+q8Cli5FnfohEz/rsv82zAiPz/LXtOGhA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@types/pdf-parse/-/pdf-parse-1.1.5.tgz}
 
   '@types/prop-types@15.7.5':
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@types/prop-types/-/prop-types-15.7.5.tgz}
@@ -4595,18 +4522,9 @@ packages:
     peerDependencies:
       graphql: ^16.8.1
 
-  pdf-parse@2.4.5:
-    resolution: {integrity: sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/pdf-parse/-/pdf-parse-2.4.5.tgz}
-    engines: {node: '>=20.16.0 <21 || >=22.3.0'}
-    hasBin: true
-
   pdfjs-dist@3.5.141:
     resolution: {integrity: sha512-lYIvyi5grtYOIatsfCifIKwxHeAJ8eHyP22DTdvY4pm0yWVSFQnMafpgCPSw8gaNRDDdcHnBVOkqMsyK8SRxZg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/pdfjs-dist/-/pdfjs-dist-3.5.141.tgz}
     engines: {node: '>=16'}
-
-  pdfjs-dist@5.4.296:
-    resolution: {integrity: sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==, tarball: https://packages.atlassian.com/api/npm/npm-remote/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz}
-    engines: {node: '>=20.16.0 || >=22.3.0'}
 
   picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/picocolors/-/picocolors-1.0.0.tgz}
@@ -7825,49 +7743,6 @@ snapshots:
       hey-listen: 1.0.8
       tslib: 2.4.0
 
-  '@napi-rs/canvas-android-arm64@0.1.80':
-    optional: true
-
-  '@napi-rs/canvas-darwin-arm64@0.1.80':
-    optional: true
-
-  '@napi-rs/canvas-darwin-x64@0.1.80':
-    optional: true
-
-  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.80':
-    optional: true
-
-  '@napi-rs/canvas-linux-arm64-gnu@0.1.80':
-    optional: true
-
-  '@napi-rs/canvas-linux-arm64-musl@0.1.80':
-    optional: true
-
-  '@napi-rs/canvas-linux-riscv64-gnu@0.1.80':
-    optional: true
-
-  '@napi-rs/canvas-linux-x64-gnu@0.1.80':
-    optional: true
-
-  '@napi-rs/canvas-linux-x64-musl@0.1.80':
-    optional: true
-
-  '@napi-rs/canvas-win32-x64-msvc@0.1.80':
-    optional: true
-
-  '@napi-rs/canvas@0.1.80':
-    optionalDependencies:
-      '@napi-rs/canvas-android-arm64': 0.1.80
-      '@napi-rs/canvas-darwin-arm64': 0.1.80
-      '@napi-rs/canvas-darwin-x64': 0.1.80
-      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.80
-      '@napi-rs/canvas-linux-arm64-gnu': 0.1.80
-      '@napi-rs/canvas-linux-arm64-musl': 0.1.80
-      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.80
-      '@napi-rs/canvas-linux-x64-gnu': 0.1.80
-      '@napi-rs/canvas-linux-x64-musl': 0.1.80
-      '@napi-rs/canvas-win32-x64-msvc': 0.1.80
-
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.9.2
@@ -8543,10 +8418,6 @@ snapshots:
       '@types/node': 18.6.2
 
   '@types/parse-json@4.0.0': {}
-
-  '@types/pdf-parse@1.1.5':
-    dependencies:
-      '@types/node': 18.6.2
 
   '@types/prop-types@15.7.5': {}
 
@@ -11257,11 +11128,6 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  pdf-parse@2.4.5:
-    dependencies:
-      '@napi-rs/canvas': 0.1.80
-      pdfjs-dist: 5.4.296
-
   pdfjs-dist@3.5.141:
     dependencies:
       path2d-polyfill: 2.0.1
@@ -11271,10 +11137,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-
-  pdfjs-dist@5.4.296:
-    optionalDependencies:
-      '@napi-rs/canvas': 0.1.80
 
   picocolors@1.0.0: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"compilerOptions": {
-		"target": "es5",
+		"target": "es2017",
 		"lib": ["dom", "dom.iterable", "esnext"],
 		"allowJs": true,
 		"skipLibCheck": true,
@@ -9,7 +9,7 @@
 		"noEmit": true,
 		"esModuleInterop": true,
 		"module": "esnext",
-		"moduleResolution": "node",
+		"moduleResolution": "bundler",
 		"resolveJsonModule": true,
 		"isolatedModules": true,
 		"jsx": "preserve",


### PR DESCRIPTION
## Summary

Enables `reactStrictMode` and disables `ignoreBuildErrors` in `next.config.js`, then fixes all resulting build failures.

## Changes to `next.config.js`

- **`reactStrictMode: true`** — React will double-invoke lifecycle methods, effects, and renders in development to help surface bugs (e.g. missing cleanup in effects, impure renders).
- **`typescript.ignoreBuildErrors: false`** — The build will now fail on TypeScript errors instead of silently ignoring them.

## Fixes

### 1. Upgrade TypeScript 4.7 → 5.8 & update `tsconfig.json`
- **TypeScript 5.8** is required for `moduleResolution: "bundler"`, which properly resolves the `exports` field in `package.json` (used by `@payloadcms/next`, `@payloadcms/ui`, etc.).
- **`target`** bumped from `es5` → `es2017` to support modern iteration patterns (`FormData.entries()`, `for-of` on iterators).
- **`moduleResolution`** changed from `node` → `bundler` so subpath exports in dependencies resolve correctly.

### 2. Add missing dependencies
- **`@payloadcms/ui`** — 3 admin components import `useDocumentInfo` from this package but it wasn't in `package.json`.
- **`lexical`** — The homepage casts rich-text content to `SerializedEditorState` from this package; added so the type resolves.

### 3. Fix PayloadCMS admin pages (`page.tsx`, `not-found.tsx`)
- Replaced deprecated `AdminViewProps` type with the local `Args` type that correctly types `params` and `searchParams` as `Promise<...>` (required by Next.js 15 App Router page contracts).
- Removed unused `AdminViewProps` imports.

### 4. Fix NextAuth route export (`route.ts`)
- Removed `export` from `authOptions` — Next.js App Router route files may only export valid HTTP handlers (`GET`, `POST`, etc.). `authOptions` is only used internally.
- Added `as string` cast for `token.customerId` assignment (JWT record values are typed as `{}` in TS 5.x).

### 5. Fix `my-orders` route type safety
- Changed `where` variable from `Record<string, unknown>` to Payload's `Where` type so it's assignable to `payload.find()`.

### 6. Fix Timeslots collection validators
- Added explicit `(value: string | null | undefined)` parameter types to `startTime` and `endTime` validators to eliminate implicit `any`.

### 7. Fix Chakra UI v2 + TS 5 incompatibility
- Added `@ts-expect-error` on the `Badge` component in `DiscountBadge.tsx` — Chakra UI v2's prop types produce a union too complex for TS 5.x to represent.

### 8. Fix `CartContextProvider` children type
- Changed props type from `React.PropsWithChildren<Record<string, never>>` to `React.PropsWithChildren` — `Record<string, never>` makes `children` incompatible.

### 9. Fix `bankTransfer.ts` type mismatch
- Widened `orderDocs` id type from `string` to `string | number` to match Payload's `TypeWithID`.

### 10. Fix `pdf-parse` dynamic import
- Replaced `.default` access with a CJS/ESM-safe pattern and explicit callable type assertion.

### 11. Fix `lib/utils.ts` implicit `any` parameters
- Added explicit types to `formatItems` and `orderSum` parameters.

### 12. Fix `pages/index.tsx` Lexical cast
- Added intermediate `unknown` cast for `section.content as SerializedEditorState` (required when types don't overlap).

### 13. Clean up `pages/order.tsx`
- Removed unused `packages` prop — `OrderContainer` accepts no props and `getStaticProps` always returns `[]`.

## Testing

✅ `pnpm build` passes cleanly with all type checks enabled.