### PR TITLE
fix: add jose as direct dependency for Cloudflare deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"framer-motion": "^6.5.1",
 		"googleapis": "^118.0.0",
 		"graphql": "^16.13.2",
+		"jose": "^5.10.0",
 		"lexical": "^0.43.0",
 		"multer": "^1.4.5-lts.1",
 		"next": "15.5.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       graphql:
         specifier: ^16.13.2
         version: 16.13.2
+      jose:
+        specifier: ^5.10.0
+        version: 5.10.0
       lexical:
         specifier: ^0.43.0
         version: 0.43.0


### PR DESCRIPTION
## Problem

When deploying to Cloudflare Workers via `opennextjs-cloudflare build`, the esbuild bundling step fails with:

```
Could not resolve "jose"
```

Payload CMS depends on `jose` for JWT operations (`auth/operations/me.js` and `auth/strategies/jwt.js`), but pnpm's strict hoisting prevents esbuild from resolving transitive dependencies.

## Fix

Add `jose` as a direct dependency so esbuild can resolve it during the OpenNext build.