### PR TITLE
fix: resolve Cloudflare Workers deployment build errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ terraform/crash.log
 
 # OpenNext
 .open-next
+.wrangler

--- a/next.config.js
+++ b/next.config.js
@@ -6,7 +6,7 @@ const nextConfig = {
 	typescript: {
 		ignoreBuildErrors: false,
 	},
-	serverExternalPackages: ["jose", "canvas"],
+	serverExternalPackages: ["jose", "pdfjs-dist"],
 };
 
 module.exports = withPayload(nextConfig);

--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,13 @@ const nextConfig = {
 	typescript: {
 		ignoreBuildErrors: false,
 	},
+	// Required for Cloudflare Workers deployment (opennextjs-cloudflare).
+	// These packages are transitive deps that pnpm's strict hoisting prevents
+	// esbuild from resolving during the OpenNext build. Adding them here ensures
+	// Next.js NFT traces them into .open-next/server-functions/default/node_modules/.
+	// - jose: used by payload for JWT auth (auth/operations/me.js, auth/strategies/jwt.js)
+	// - pdfjs-dist: only used client-side, but gets traced into server bundle where
+	//   it tries to require("canvas") which is a native addon incompatible with Workers
 	serverExternalPackages: ["jose", "pdfjs-dist"],
 };
 

--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,7 @@ const nextConfig = {
 	typescript: {
 		ignoreBuildErrors: false,
 	},
+	serverExternalPackages: ["jose"],
 };
 
 module.exports = withPayload(nextConfig);

--- a/next.config.js
+++ b/next.config.js
@@ -6,7 +6,7 @@ const nextConfig = {
 	typescript: {
 		ignoreBuildErrors: false,
 	},
-	serverExternalPackages: ["jose"],
+	serverExternalPackages: ["jose", "canvas"],
 };
 
 module.exports = withPayload(nextConfig);

--- a/package.json
+++ b/package.json
@@ -70,12 +70,14 @@
 		"node": ">=20",
 		"pnpm": "^10.0.0"
 	},
+	"//cloudflare-workarounds": "jose is an explicit dep because payload uses it for JWT but pnpm doesn't hoist it for the OpenNext esbuild step. canvas is overridden with a local stub because pdfjs-dist optionally requires it (native addon) which breaks esbuild. See next.config.js and shims/canvas/index.js for more details.",
 	"packageManager": "pnpm@10.11.0",
 	"pnpm": {
 		"onlyBuiltDependencies": [
 			"esbuild",
 			"sharp"
 		],
+		"//overrides": "Needed for Cloudflare Workers deployment. canvas is a native Node.js addon required by pdfjs-dist that breaks esbuild bundling. See shims/canvas/index.js for details.",
 		"overrides": {
 			"canvas": "link:./shims/canvas"
 		}

--- a/package.json
+++ b/package.json
@@ -75,6 +75,9 @@
 		"onlyBuiltDependencies": [
 			"esbuild",
 			"sharp"
-		]
+		],
+		"overrides": {
+			"canvas": "link:./shims/canvas"
+		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  canvas: link:./shims/canvas
+
 importers:
 
   .:
@@ -2259,10 +2262,6 @@ packages:
     peerDependencies:
       yjs: '>=13.5.22'
 
-  '@mapbox/node-pre-gyp@1.0.10':
-    resolution: {integrity: sha512-4ySo4CjzStuprMwk35H5pPbkymjv1SF3jGLj6rAHp/xT/RF7TL7bd9CTm1xDY49K2qF7jmR/g7k+SkLETP6opA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.10.tgz}
-    hasBin: true
-
   '@monaco-editor/loader@1.7.0':
     resolution: {integrity: sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@monaco-editor/loader/-/loader-1.7.0.tgz}
 
@@ -3125,9 +3124,6 @@ packages:
   '@zag-js/focus-visible@0.1.0':
     resolution: {integrity: sha512-PeaBcTmdZWcFf7n1aM+oiOdZc+sy14qi0emPIeUuGMTjbP0xLGrZu43kdpHnWSXy7/r4Ubp/vlg50MCV8+9Isg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@zag-js/focus-visible/-/focus-visible-0.1.0.tgz}
 
-  abbrev@1.1.1:
-    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==, tarball: https://packages.atlassian.com/api/npm/npm-remote/abbrev/-/abbrev-1.1.1.tgz}
-
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/abort-controller/-/abort-controller-3.0.0.tgz}
     engines: {node: '>=6.5'}
@@ -3195,14 +3191,6 @@ packages:
 
   append-field@1.0.0:
     resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/append-field/-/append-field-1.0.0.tgz}
-
-  aproba@2.0.0:
-    resolution: {integrity: sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/aproba/-/aproba-2.0.0.tgz}
-
-  are-we-there-yet@2.0.0:
-    resolution: {integrity: sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz}
-    engines: {node: '>=10'}
-    deprecated: This package is no longer supported.
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==, tarball: https://packages.atlassian.com/api/npm/npm-remote/argparse/-/argparse-2.0.1.tgz}
@@ -3401,10 +3389,6 @@ packages:
   caniuse-lite@1.0.30001788:
     resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz}
 
-  canvas@2.11.2:
-    resolution: {integrity: sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/canvas/-/canvas-2.11.2.tgz}
-    engines: {node: '>=6'}
-
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/ccount/-/ccount-2.0.1.tgz}
 
@@ -3441,10 +3425,6 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/chokidar/-/chokidar-3.6.0.tgz}
     engines: {node: '>= 8.10.0'}
-
-  chownr@2.0.0:
-    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/chownr/-/chownr-2.0.0.tgz}
-    engines: {node: '>=10'}
 
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/ci-info/-/ci-info-4.4.0.tgz}
@@ -3484,10 +3464,6 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/color-name/-/color-name-1.1.4.tgz}
 
-  color-support@1.1.3:
-    resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/color-support/-/color-support-1.1.3.tgz}
-    hasBin: true
-
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==, tarball: https://packages.atlassian.com/api/npm/npm-remote/colorette/-/colorette-2.0.20.tgz}
 
@@ -3515,9 +3491,6 @@ packages:
   concat-stream@1.6.2:
     resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/concat-stream/-/concat-stream-1.6.2.tgz}
     engines: {'0': node >= 0.8}
-
-  console-control-strings@1.1.0:
-    resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/console-control-strings/-/console-control-strings-1.1.0.tgz}
 
   console-table-printer@2.12.1:
     resolution: {integrity: sha512-wKGOQRRvdnd89pCeH96e2Fn4wkbenSP6LMHfjfyNLMbGuHEFbMqQNuxXqd0oXG9caIOQ1FTvc5Uijp9/4jujnQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/console-table-printer/-/console-table-printer-2.12.1.tgz}
@@ -3640,10 +3613,6 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==, tarball: https://packages.atlassian.com/api/npm/npm-remote/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz}
 
-  decompress-response@4.2.1:
-    resolution: {integrity: sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/decompress-response/-/decompress-response-4.2.1.tgz}
-    engines: {node: '>=8'}
-
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/deep-is/-/deep-is-0.1.4.tgz}
 
@@ -3667,9 +3636,6 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/delayed-stream/-/delayed-stream-1.0.0.tgz}
     engines: {node: '>=0.4.0'}
 
-  delegates@1.0.0:
-    resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/delegates/-/delegates-1.0.0.tgz}
-
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/depd/-/depd-2.0.0.tgz}
     engines: {node: '>= 0.8'}
@@ -3681,10 +3647,6 @@ packages:
   detect-file@1.0.0:
     resolution: {integrity: sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q==, tarball: https://packages.atlassian.com/api/npm/npm-remote/detect-file/-/detect-file-1.0.0.tgz}
     engines: {node: '>=0.10.0'}
-
-  detect-libc@2.0.1:
-    resolution: {integrity: sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==, tarball: https://packages.atlassian.com/api/npm/npm-remote/detect-libc/-/detect-libc-2.0.1.tgz}
-    engines: {node: '>=8'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/detect-libc/-/detect-libc-2.1.2.tgz}
@@ -4159,10 +4121,6 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==, tarball: https://packages.atlassian.com/api/npm/npm-remote/fresh/-/fresh-2.0.0.tgz}
     engines: {node: '>= 0.8'}
 
-  fs-minipass@2.1.0:
-    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/fs-minipass/-/fs-minipass-2.1.0.tgz}
-    engines: {node: '>= 8'}
-
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/fs.realpath/-/fs.realpath-1.0.0.tgz}
 
@@ -4195,11 +4153,6 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/functions-have-names/-/functions-have-names-1.2.3.tgz}
-
-  gauge@3.0.2:
-    resolution: {integrity: sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==, tarball: https://packages.atlassian.com/api/npm/npm-remote/gauge/-/gauge-3.0.2.tgz}
-    engines: {node: '>=10'}
-    deprecated: This package is no longer supported.
 
   gaxios@5.1.0:
     resolution: {integrity: sha512-aezGIjb+/VfsJtIcHGcBSerNEDdfdHeMros+RbYbGpmonKWQCOVOes0LVZhn1lDtIgq55qq0HaxymIoae3Fl/A==, tarball: https://packages.atlassian.com/api/npm/npm-remote/gaxios/-/gaxios-5.1.0.tgz}
@@ -4273,7 +4226,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==, tarball: https://packages.atlassian.com/api/npm/npm-remote/glob/-/glob-7.2.3.tgz}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@9.3.5:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==, tarball: https://packages.atlassian.com/api/npm/npm-remote/glob/-/glob-9.3.5.tgz}
@@ -4393,9 +4346,6 @@ packages:
   has-tostringtag@1.0.2:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/has-tostringtag/-/has-tostringtag-1.0.2.tgz}
     engines: {node: '>= 0.4'}
-
-  has-unicode@2.0.1:
-    resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/has-unicode/-/has-unicode-2.0.1.tgz}
 
   has@1.0.3:
     resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/has/-/has-1.0.3.tgz}
@@ -4929,10 +4879,6 @@ packages:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/lru-cache/-/lru-cache-6.0.0.tgz}
     engines: {node: '>=10'}
 
-  make-dir@3.1.0:
-    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/make-dir/-/make-dir-3.1.0.tgz}
-    engines: {node: '>=8'}
-
   marked@14.0.0:
     resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/marked/-/marked-14.0.0.tgz}
     engines: {node: '>= 18'}
@@ -5084,10 +5030,6 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/mimic-fn/-/mimic-fn-2.1.0.tgz}
     engines: {node: '>=6'}
 
-  mimic-response@2.1.0:
-    resolution: {integrity: sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/mimic-response/-/mimic-response-2.1.0.tgz}
-    engines: {node: '>=8'}
-
   miniflare@4.20260415.0:
     resolution: {integrity: sha512-JoExRWN4YBI2luA5BoSMFEgi8rQWXUGzo3mtE+58VXCLV3jj/Xnk5Yeqs/IXWz8Es5GJIaq6BtsixDvAxXSIng==, tarball: https://packages.atlassian.com/api/npm/npm-remote/miniflare/-/miniflare-4.20260415.0.tgz}
     engines: {node: '>=18.0.0'}
@@ -5110,10 +5052,6 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/minimist/-/minimist-1.2.8.tgz}
 
-  minipass@3.3.6:
-    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/minipass/-/minipass-3.3.6.tgz}
-    engines: {node: '>=8'}
-
   minipass@4.2.8:
     resolution: {integrity: sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/minipass/-/minipass-4.2.8.tgz}
     engines: {node: '>=8'}
@@ -5121,10 +5059,6 @@ packages:
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==, tarball: https://packages.atlassian.com/api/npm/npm-remote/minipass/-/minipass-7.1.3.tgz}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  minizlib@2.1.2:
-    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/minizlib/-/minizlib-2.1.2.tgz}
-    engines: {node: '>= 8'}
 
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/mkdirp/-/mkdirp-0.5.6.tgz}
@@ -5207,9 +5141,6 @@ packages:
     resolution: {integrity: sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/multer/-/multer-1.4.5-lts.1.tgz}
     engines: {node: '>= 6.0.0'}
     deprecated: Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.
-
-  nan@2.17.0:
-    resolution: {integrity: sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/nan/-/nan-2.17.0.tgz}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==, tarball: https://packages.atlassian.com/api/npm/npm-remote/nanoid/-/nanoid-3.3.11.tgz}
@@ -5307,11 +5238,6 @@ packages:
     resolution: {integrity: sha512-nsrh2lO3j4GkLLXoeEksAMgAOqxOv6QumNRVQTJwKH4nuiww6iC2y7GyANs9kRAxCexg3+lTWM3PZ91iLlVjfg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/nodemailer/-/nodemailer-7.0.5.tgz}
     engines: {node: '>=6.0.0'}
 
-  nopt@5.0.0:
-    resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/nopt/-/nopt-5.0.0.tgz}
-    engines: {node: '>=6'}
-    hasBin: true
-
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/normalize-path/-/normalize-path-3.0.0.tgz}
     engines: {node: '>=0.10.0'}
@@ -5319,10 +5245,6 @@ packages:
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/npm-run-path/-/npm-run-path-4.0.1.tgz}
     engines: {node: '>=8'}
-
-  npmlog@5.0.1:
-    resolution: {integrity: sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/npmlog/-/npmlog-5.0.1.tgz}
-    deprecated: This package is no longer supported.
 
   oauth4webapi@3.8.5:
     resolution: {integrity: sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/oauth4webapi/-/oauth4webapi-3.8.5.tgz}
@@ -5873,17 +5795,8 @@ packages:
   secure-json-parse@4.1.0:
     resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/secure-json-parse/-/secure-json-parse-4.1.0.tgz}
 
-  semver@6.3.0:
-    resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/semver/-/semver-6.3.0.tgz}
-    hasBin: true
-
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/semver/-/semver-6.3.1.tgz}
-    hasBin: true
-
-  semver@7.3.7:
-    resolution: {integrity: sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==, tarball: https://packages.atlassian.com/api/npm/npm-remote/semver/-/semver-7.3.7.tgz}
-    engines: {node: '>=10'}
     hasBin: true
 
   semver@7.7.4:
@@ -5898,9 +5811,6 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/serve-static/-/serve-static-2.2.1.tgz}
     engines: {node: '>= 18'}
-
-  set-blocking@2.0.0:
-    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/set-blocking/-/set-blocking-2.0.0.tgz}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/set-function-length/-/set-function-length-1.2.2.tgz}
@@ -5957,12 +5867,6 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/signal-exit/-/signal-exit-4.1.0.tgz}
     engines: {node: '>=14'}
-
-  simple-concat@1.0.1:
-    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==, tarball: https://packages.atlassian.com/api/npm/npm-remote/simple-concat/-/simple-concat-1.0.1.tgz}
-
-  simple-get@3.1.1:
-    resolution: {integrity: sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/simple-get/-/simple-get-3.1.1.tgz}
 
   simple-wcswidth@1.1.2:
     resolution: {integrity: sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz}
@@ -6144,10 +6048,6 @@ packages:
 
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/tabbable/-/tabbable-6.4.0.tgz}
-
-  tar@6.1.13:
-    resolution: {integrity: sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/tar/-/tar-6.1.13.tgz}
-    engines: {node: '>=10'}
 
   terser@5.16.9:
     resolution: {integrity: sha512-HPa/FdTB9XGI2H1/keLFZHxl6WNvAI4YalHGtDQTlMnJcoqSab1UwL4l1hGEhs6/GmLHBZIg/YgB++jcbzoOEg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/terser/-/terser-5.16.9.tgz}
@@ -6482,9 +6382,6 @@ packages:
     resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/which/-/which-4.0.0.tgz}
     engines: {node: ^16.13.0 || >=18.0.0}
     hasBin: true
-
-  wide-align@1.1.5:
-    resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/wide-align/-/wide-align-1.1.5.tgz}
 
   with@7.0.2:
     resolution: {integrity: sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==, tarball: https://packages.atlassian.com/api/npm/npm-remote/with/-/with-7.0.2.tgz}
@@ -9364,22 +9261,6 @@ snapshots:
       lexical: 0.41.0
       yjs: 13.6.30
 
-  '@mapbox/node-pre-gyp@1.0.10':
-    dependencies:
-      detect-libc: 2.0.1
-      https-proxy-agent: 5.0.1
-      make-dir: 3.1.0
-      node-fetch: 2.6.9
-      nopt: 5.0.0
-      npmlog: 5.0.1
-      rimraf: 3.0.2
-      semver: 7.3.7
-      tar: 6.1.13
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    optional: true
-
   '@monaco-editor/loader@1.7.0':
     dependencies:
       state-local: 1.0.7
@@ -10552,9 +10433,6 @@ snapshots:
 
   '@zag-js/focus-visible@0.1.0': {}
 
-  abbrev@1.1.1:
-    optional: true
-
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -10618,15 +10496,6 @@ snapshots:
       picomatch: 2.3.1
 
   append-field@1.0.0: {}
-
-  aproba@2.0.0:
-    optional: true
-
-  are-we-there-yet@2.0.0:
-    dependencies:
-      delegates: 1.0.0
-      readable-stream: 3.6.2
-    optional: true
 
   argparse@2.0.1: {}
 
@@ -10843,16 +10712,6 @@ snapshots:
 
   caniuse-lite@1.0.30001788: {}
 
-  canvas@2.11.2:
-    dependencies:
-      '@mapbox/node-pre-gyp': 1.0.10
-      nan: 2.17.0
-      simple-get: 3.1.1
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    optional: true
-
   ccount@2.0.1: {}
 
   chalk@2.4.2:
@@ -10893,9 +10752,6 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
-
-  chownr@2.0.0:
-    optional: true
 
   ci-info@4.4.0: {}
 
@@ -10945,9 +10801,6 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  color-support@1.1.3:
-    optional: true
-
   colorette@2.0.20: {}
 
   combined-stream@1.0.8:
@@ -10973,9 +10826,6 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 2.3.8
       typedarray: 0.0.6
-
-  console-control-strings@1.1.0:
-    optional: true
 
   console-table-printer@2.12.1:
     dependencies:
@@ -11080,11 +10930,6 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
-  decompress-response@4.2.1:
-    dependencies:
-      mimic-response: 2.1.0
-    optional: true
-
   deep-is@0.1.4: {}
 
   deepmerge@4.3.1: {}
@@ -11108,17 +10953,11 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
-  delegates@1.0.0:
-    optional: true
-
   depd@2.0.0: {}
 
   dequal@2.0.3: {}
 
   detect-file@1.0.0: {}
-
-  detect-libc@2.0.1:
-    optional: true
 
   detect-libc@2.1.2: {}
 
@@ -11932,11 +11771,6 @@ snapshots:
 
   fresh@2.0.0: {}
 
-  fs-minipass@2.1.0:
-    dependencies:
-      minipass: 3.3.6
-    optional: true
-
   fs.realpath@1.0.0: {}
 
   fsevents@2.3.2:
@@ -11968,19 +11802,6 @@ snapshots:
   functional-red-black-tree@1.0.1: {}
 
   functions-have-names@1.2.3: {}
-
-  gauge@3.0.2:
-    dependencies:
-      aproba: 2.0.0
-      color-support: 1.1.3
-      console-control-strings: 1.1.0
-      has-unicode: 2.0.1
-      object-assign: 4.1.1
-      signal-exit: 3.0.7
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wide-align: 1.1.5
-    optional: true
 
   gaxios@5.1.0:
     dependencies:
@@ -12232,9 +12053,6 @@ snapshots:
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.0.3
-
-  has-unicode@2.0.1:
-    optional: true
 
   has@1.0.3:
     dependencies:
@@ -12726,11 +12544,6 @@ snapshots:
     dependencies:
       yallist: 4.0.0
 
-  make-dir@3.1.0:
-    dependencies:
-      semver: 6.3.0
-    optional: true
-
   marked@14.0.0: {}
 
   math-intrinsics@1.1.0: {}
@@ -13000,9 +12813,6 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
-  mimic-response@2.1.0:
-    optional: true
-
   miniflare@4.20260415.0:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -13031,20 +12841,9 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minipass@3.3.6:
-    dependencies:
-      yallist: 4.0.0
-    optional: true
-
   minipass@4.2.8: {}
 
   minipass@7.1.3: {}
-
-  minizlib@2.1.2:
-    dependencies:
-      minipass: 3.3.6
-      yallist: 4.0.0
-    optional: true
 
   mkdirp@0.5.6:
     dependencies:
@@ -13128,9 +12927,6 @@ snapshots:
       type-is: 1.6.18
       xtend: 4.0.2
 
-  nan@2.17.0:
-    optional: true
-
   nanoid@3.3.11: {}
 
   napi-postinstall@0.3.4: {}
@@ -13210,24 +13006,11 @@ snapshots:
 
   nodemailer@7.0.5: {}
 
-  nopt@5.0.0:
-    dependencies:
-      abbrev: 1.1.1
-    optional: true
-
   normalize-path@3.0.0: {}
 
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
-
-  npmlog@5.0.1:
-    dependencies:
-      are-we-there-yet: 2.0.0
-      console-control-strings: 1.1.0
-      gauge: 3.0.2
-      set-blocking: 2.0.0
-    optional: true
 
   oauth4webapi@3.8.5: {}
 
@@ -13430,10 +13213,7 @@ snapshots:
       path2d-polyfill: 2.0.1
       web-streams-polyfill: 3.2.1
     optionalDependencies:
-      canvas: 2.11.2
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
+      canvas: link:shims/canvas
 
   picocolors@1.0.0: {}
 
@@ -13917,15 +13697,7 @@ snapshots:
 
   secure-json-parse@4.1.0: {}
 
-  semver@6.3.0:
-    optional: true
-
   semver@6.3.1: {}
-
-  semver@7.3.7:
-    dependencies:
-      lru-cache: 6.0.0
-    optional: true
 
   semver@7.7.4: {}
 
@@ -13953,9 +13725,6 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
-
-  set-blocking@2.0.0:
-    optional: true
 
   set-function-length@1.2.2:
     dependencies:
@@ -14057,16 +13826,6 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
-
-  simple-concat@1.0.1:
-    optional: true
-
-  simple-get@3.1.1:
-    dependencies:
-      decompress-response: 4.2.1
-      once: 1.4.0
-      simple-concat: 1.0.1
-    optional: true
 
   simple-wcswidth@1.1.2: {}
 
@@ -14259,16 +14018,6 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   tabbable@6.4.0: {}
-
-  tar@6.1.13:
-    dependencies:
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      minipass: 4.2.8
-      minizlib: 2.1.2
-      mkdirp: 1.0.4
-      yallist: 4.0.0
-    optional: true
 
   terser@5.16.9:
     dependencies:
@@ -14640,11 +14389,6 @@ snapshots:
   which@4.0.0:
     dependencies:
       isexe: 3.1.5
-
-  wide-align@1.1.5:
-    dependencies:
-      string-width: 4.2.3
-    optional: true
 
   with@7.0.2:
     dependencies:

--- a/shims/canvas/index.js
+++ b/shims/canvas/index.js
@@ -1,3 +1,11 @@
-// Stub for canvas - only needed for server-side PDF rendering which we don't use.
-// pdfjs-dist optionally requires canvas for Node.js, but we only use it client-side.
+// Stub replacement for the "canvas" npm package (a native C++ Node.js addon).
+//
+// pdfjs-dist optionally requires canvas for server-side PDF rendering in Node.js.
+// We only use pdfjs-dist client-side (PdfOrder component), where the browser's
+// native <canvas> element is used instead.
+//
+// The real canvas package can't be bundled by esbuild (it contains .node binaries)
+// and can't run on Cloudflare Workers. This stub is referenced via pnpm.overrides
+// in package.json to satisfy the require("canvas") call in pdfjs-dist without
+// pulling in the native addon.
 module.exports = {};

--- a/shims/canvas/index.js
+++ b/shims/canvas/index.js
@@ -1,0 +1,3 @@
+// Stub for canvas - only needed for server-side PDF rendering which we don't use.
+// pdfjs-dist optionally requires canvas for Node.js, but we only use it client-side.
+module.exports = {};

--- a/shims/canvas/package.json
+++ b/shims/canvas/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "canvas",
+	"version": "0.0.0",
+	"main": "index.js"
+}


### PR DESCRIPTION
## Problem

When deploying to Cloudflare Workers via `opennextjs-cloudflare build`, the esbuild bundling step fails with:

- `Could not resolve "jose"` — payload depends on jose for JWT auth, but pnpm's strict hoisting prevents esbuild from resolving it in the `.open-next` output
- `Could not resolve "canvas"` — pdfjs-dist optionally requires canvas (a native C++ Node.js addon) for server-side PDF rendering, which can't be bundled by esbuild or run on Workers

## Fix

- Add `jose` as an explicit dependency so esbuild can resolve it
- Add `jose` and `pdfjs-dist` to `serverExternalPackages` so Next.js NFT traces them into `.open-next/server-functions/default/node_modules/`
- Override `canvas` with a local stub package (`shims/canvas/`) via `pnpm.overrides` to satisfy the `require("canvas")` call without pulling in the native addon
- Add `.wrangler` to `.gitignore`

## Notes

- `pdfjs-dist` is only used client-side (`PdfOrder` component) — canvas is never needed at runtime
- Comments added to all workarounds so future devs know why they're there