### PR TITLE
chore: remove unused Google service account env vars

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -20,56 +20,6 @@ declare namespace NodeJS {
 		 */
 		PAYLOAD_SECRET: string;
 		/**
-		 * @env type
-		 * Google service account field. Obtain from your Google Cloud service account JSON.
-		 */
-		type: string;
-		/**
-		 * @env project_id
-		 * Google service account field. Obtain from your Google Cloud service account JSON.
-		 */
-		project_id: string;
-		/**
-		 * @env private_key_id
-		 * Google service account field. Obtain from your Google Cloud service account JSON.
-		 */
-		private_key_id: string;
-		/**
-		 * @env private_key
-		 * Google service account field. Obtain from your Google Cloud service account JSON.
-		 */
-		private_key: string;
-		/**
-		 * @env client_email
-		 * Google service account field. Obtain from your Google Cloud service account JSON.
-		 */
-		client_email: string;
-		/**
-		 * @env client_id
-		 * Google service account field. Obtain from your Google Cloud service account JSON.
-		 */
-		client_id: string;
-		/**
-		 * @env auth_uri
-		 * Google service account field. Obtain from your Google Cloud service account JSON.
-		 */
-		auth_uri: string;
-		/**
-		 * @env token_uri
-		 * Google service account field. Obtain from your Google Cloud service account JSON.
-		 */
-		token_uri: string;
-		/**
-		 * @env auth_provider_x509_cert_url
-		 * Google service account field. Obtain from your Google Cloud service account JSON.
-		 */
-		auth_provider_x509_cert_url: string;
-		/**
-		 * @env client_x509_cert_url
-		 * Google service account field. Obtain from your Google Cloud service account JSON.
-		 */
-		client_x509_cert_url: string;
-		/**
 		 * @env R2_BUCKET
 		 * Cloudflare R2 bucket name for Payload CMS media uploads.
 		 */


### PR DESCRIPTION
## Summary

Removes 10 unused Google service account environment variable declarations from `env.d.ts`.

These were left over from the old Google Sheets integration (Sheets API) which has since been removed. None of these vars are referenced anywhere in the codebase:

`type`, `project_id`, `private_key_id`, `private_key`, `client_email`, `client_id`, `auth_uri`, `token_uri`, `auth_provider_x509_cert_url`, `client_x509_cert_url`

**Note:** The Google OAuth vars (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`) are still used by NextAuth and are kept.