### PR TITLE
fix: externalize sharp for Cloudflare Workers deployment

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -13,7 +13,9 @@ const nextConfig = {
 	// - jose: used by payload for JWT auth (auth/operations/me.js, auth/strategies/jwt.js)
 	// - pdfjs-dist: only used client-side, but gets traced into server bundle where
 	//   it tries to require("canvas") which is a native addon incompatible with Workers
-	serverExternalPackages: ["jose", "pdfjs-dist"],
+	// - sharp: native image processing addon used by payload — can't be bundled by esbuild.
+	//   Externalized so the build succeeds; at runtime on Workers it may fall back gracefully.
+	serverExternalPackages: ["jose", "pdfjs-dist", "sharp"],
 };
 
 module.exports = withPayload(nextConfig);

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"@chakra-ui/react": "^2.2.4",
 		"@emotion/react": "^11.9.3",
 		"@emotion/styled": "^11.9.3",
+		"@img/sharp-wasm32": "^0.34.5",
 		"@opennextjs/cloudflare": "^1.19.1",
 		"@payloadcms/db-mongodb": "^3.82.1",
 		"@payloadcms/next": "^3.82.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@emotion/styled':
         specifier: ^11.9.3
         version: 11.9.3(@babel/core@7.18.9)(@emotion/react@11.9.3(@babel/core@7.18.9)(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5)
+      '@img/sharp-wasm32':
+        specifier: ^0.34.5
+        version: 0.34.5
       '@opennextjs/cloudflare':
         specifier: ^1.19.1
         version: 1.19.1(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(wrangler@4.83.0)
@@ -8154,8 +8157,7 @@ snapshots:
 
   '@emnapi/runtime@1.9.2':
     dependencies:
-      tslib: 2.4.0
-    optional: true
+      tslib: 2.8.1
 
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
@@ -9047,7 +9049,6 @@ snapshots:
   '@img/sharp-wasm32@0.34.5':
     dependencies:
       '@emnapi/runtime': 1.9.2
-    optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
     optional: true
@@ -9295,7 +9296,7 @@ snapshots:
   '@motionone/easing@10.13.1':
     dependencies:
       '@motionone/utils': 10.13.1
-      tslib: 2.4.0
+      tslib: 2.8.1
 
   '@motionone/generators@10.13.1':
     dependencies:
@@ -11716,7 +11717,7 @@ snapshots:
 
   focus-lock@0.11.2:
     dependencies:
-      tslib: 2.4.0
+      tslib: 2.8.1
 
   focus-trap@7.5.4:
     dependencies:


### PR DESCRIPTION
## Problem

Payload CMS uses `sharp` for image processing (resizing, thumbnails). sharp is a native C++ addon that can't be bundled by esbuild or run directly on Cloudflare Workers, causing:

```
Error: Could not load the "sharp" module using the linuxnull-x64 runtime
Dynamic require of "@img/sharp-linuxnull-x64/sharp.node" is not supported
```

## Fix

- Add `sharp` to `serverExternalPackages` in `next.config.js` to prevent esbuild from trying to bundle native bindings
- Add `@img/sharp-wasm32` as a dependency — this is the WebAssembly build of sharp that can run on Workers

## Notes

If image optimization still fails at runtime on Workers, Cloudflare's own [Image Transformations](https://developers.cloudflare.com/images/transform-images/) can be used as an alternative.