### PR TITLE
fix: remove sharp for Cloudflare Workers compatibility

### DIFF
--- a/app/api/shop/upload-proof/route.ts
+++ b/app/api/shop/upload-proof/route.ts
@@ -80,7 +80,11 @@ export async function POST(request: NextRequest) {
 		}
 
 		const buffer = Buffer.from(await image.arrayBuffer());
-		const proofKey = await uploadBankTransferProof(orderNumber, buffer, image.type);
+		const proofKey = await uploadBankTransferProof(
+			orderNumber,
+			buffer,
+			image.type,
+		);
 
 		return NextResponse.json({
 			success: true,

--- a/app/api/shop/upload-proof/route.ts
+++ b/app/api/shop/upload-proof/route.ts
@@ -10,8 +10,8 @@ import { uploadBankTransferProof } from "../../../../lib/r2";
  * - `image` (JPEG/PNG/WebP file, max 10MB)
  * - `orderNumber` (string)
  *
- * The image is automatically downsized to max 1200px width and converted
- * to WebP at 70% quality to prevent abuse / save storage.
+ * The image is uploaded as-is (no server-side resizing — sharp is not
+ * available on Cloudflare Workers).
  *
  * Returns the R2 key to attach to the order.
  */
@@ -80,7 +80,7 @@ export async function POST(request: NextRequest) {
 		}
 
 		const buffer = Buffer.from(await image.arrayBuffer());
-		const proofKey = await uploadBankTransferProof(orderNumber, buffer);
+		const proofKey = await uploadBankTransferProof(orderNumber, buffer, image.type);
 
 		return NextResponse.json({
 			success: true,

--- a/lib/r2.ts
+++ b/lib/r2.ts
@@ -7,6 +7,7 @@ import {
 	S3Client,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+
 // sharp removed — native C++ addon incompatible with Cloudflare Workers.
 // Bank transfer proof images are uploaded without server-side resizing.
 

--- a/lib/r2.ts
+++ b/lib/r2.ts
@@ -7,7 +7,8 @@ import {
 	S3Client,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
-import sharp from "sharp";
+// sharp removed — native C++ addon incompatible with Cloudflare Workers.
+// Bank transfer proof images are uploaded without server-side resizing.
 
 // ── S3-compatible client (shared across all R2 buckets) ──────────────────
 
@@ -101,16 +102,13 @@ export async function uploadToStaging(
 export async function uploadBankTransferProof(
 	orderNumber: string,
 	imageBuffer: Buffer | Uint8Array,
+	contentType = "image/jpeg",
 ): Promise<string> {
 	const key = generateProofKey(orderNumber);
 
-	// Downsize & convert to WebP
-	const processed = await sharp(imageBuffer)
-		.resize({ width: 1200, withoutEnlargement: true })
-		.webp({ quality: 70 })
-		.toBuffer();
-
-	await uploadToStaging(key, processed, "image/webp");
+	// Previously used sharp to resize/convert to WebP, but sharp's native
+	// bindings are incompatible with Cloudflare Workers. Upload original instead.
+	await uploadToStaging(key, imageBuffer, contentType);
 	return key;
 }
 

--- a/next.config.js
+++ b/next.config.js
@@ -13,9 +13,7 @@ const nextConfig = {
 	// - jose: used by payload for JWT auth (auth/operations/me.js, auth/strategies/jwt.js)
 	// - pdfjs-dist: only used client-side, but gets traced into server bundle where
 	//   it tries to require("canvas") which is a native addon incompatible with Workers
-	// - sharp: native image processing addon used by payload — can't be bundled by esbuild.
-	//   Externalized so the build succeeds; at runtime on Workers it may fall back gracefully.
-	serverExternalPackages: ["jose", "pdfjs-dist", "sharp"],
+	serverExternalPackages: ["jose", "pdfjs-dist"],
 };
 
 module.exports = withPayload(nextConfig);

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
 		"@chakra-ui/react": "^2.2.4",
 		"@emotion/react": "^11.9.3",
 		"@emotion/styled": "^11.9.3",
-		"@img/sharp-wasm32": "^0.34.5",
 		"@opennextjs/cloudflare": "^1.19.1",
 		"@payloadcms/db-mongodb": "^3.82.1",
 		"@payloadcms/next": "^3.82.1",
@@ -51,7 +50,6 @@
 		"react": "19.2.5",
 		"react-dom": "19.2.5",
 		"react-messenger-chat-plugin": "^3.0.5",
-		"sharp": "^0.34.5",
 		"stripe": "^12.1.1",
 		"tsx": "^4.20.3",
 		"zod": "^4.0.5"
@@ -75,8 +73,7 @@
 	"packageManager": "pnpm@10.11.0",
 	"pnpm": {
 		"onlyBuiltDependencies": [
-			"esbuild",
-			"sharp"
+			"esbuild"
 		],
 		"//overrides": "Needed for Cloudflare Workers deployment. canvas is a native Node.js addon required by pdfjs-dist that breaks esbuild bundling. See shims/canvas/index.js for details.",
 		"overrides": {

--- a/payload.config.ts
+++ b/payload.config.ts
@@ -4,7 +4,8 @@ import { mongooseAdapter } from "@payloadcms/db-mongodb";
 import { lexicalEditor } from "@payloadcms/richtext-lexical";
 import { s3Storage } from "@payloadcms/storage-s3";
 import { buildConfig } from "payload";
-import sharp from "sharp";
+// sharp removed — native C++ addon incompatible with Cloudflare Workers.
+// Images are stored at original size in R2 and served via presigned URLs.
 import { AboutSections } from "./collections/AboutSections";
 import { Customers } from "./collections/Customers";
 import { Media } from "./collections/Media";
@@ -25,7 +26,6 @@ export default buildConfig({
 	editor: lexicalEditor(),
 	collections: [Users, Customers, Orders, Timeslots, AboutSections, Media],
 	globals: [ContactInfo, BankDetails],
-	sharp,
 	plugins: [
 		...(process.env.R2_S3_ENDPOINT
 			? [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       '@emotion/styled':
         specifier: ^11.9.3
         version: 11.9.3(@babel/core@7.18.9)(@emotion/react@11.9.3(@babel/core@7.18.9)(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5)
-      '@img/sharp-wasm32':
-        specifier: ^0.34.5
-        version: 0.34.5
       '@opennextjs/cloudflare':
         specifier: ^1.19.1
         version: 1.19.1(next@15.5.15(@babel/core@7.18.9)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))(wrangler@4.83.0)
@@ -119,9 +116,6 @@ importers:
       react-messenger-chat-plugin:
         specifier: ^3.0.5
         version: 3.0.5
-      sharp:
-        specifier: ^0.34.5
-        version: 0.34.5
       stripe:
         specifier: ^12.1.1
         version: 12.1.1
@@ -8158,6 +8152,7 @@ snapshots:
   '@emnapi/runtime@1.9.2':
     dependencies:
       tslib: 2.8.1
+    optional: true
 
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
@@ -9049,6 +9044,7 @@ snapshots:
   '@img/sharp-wasm32@0.34.5':
     dependencies:
       '@emnapi/runtime': 1.9.2
+    optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
     optional: true


### PR DESCRIPTION
## Problem

sharp is a native C++ image processing addon that can't run on Cloudflare Workers. It was used in two places:

1. **Payload CMS** (`payload.config.ts`) — server-side image optimization on upload
2. **Bank transfer proofs** (`lib/r2.ts`) — resizing to 1200px and converting to WebP

## Fix

Remove sharp entirely:
- **Payload**: no `sharp` config → images stored at original size in R2
- **Bank transfer proofs**: uploaded as-is with original content type instead of resizing/converting
- **Dependencies**: removed `sharp` and `@img/sharp-wasm32` from package.json
- **serverExternalPackages**: removed `sharp` (no longer imported)

## Why not Cloudflare Image Transforms?

Media and proof images are served via **presigned R2 URLs** (temporary signed URLs directly to R2), which bypass the Cloudflare CDN. Image Transforms only work on requests routed through Cloudflare's proxy, so they aren't applicable here.

## Trade-off

Images are no longer server-side optimized. For most use cases this is fine — browser-based resizing/lazy loading handles display. If server-side processing is needed in the future, consider a Cloudflare Worker-based image pipeline using the Images API.