### PR TITLE
fix: prevent Worker hangs and fix undefined .includes() crash

### DIFF
--- a/components/ordercontainer/OrderContainer.tsx
+++ b/components/ordercontainer/OrderContainer.tsx
@@ -94,6 +94,11 @@ const OrderContainerInner = () => {
 				const data = await res.json();
 				const order = data.order;
 
+				if (!order?.status) {
+					setResumeChecked(true);
+					return;
+				}
+
 				if (order.status === OrderStatus.EXPIRED) {
 					// Can't resume expired orders
 					setResumeChecked(true);

--- a/components/ordercontainer/OrderSteps.tsx
+++ b/components/ordercontainer/OrderSteps.tsx
@@ -66,11 +66,14 @@ export default function OrderSteps({
 				const res = await fetch(`/api/shop/${orderId}`);
 				if (res.ok) {
 					const data = await res.json();
-					setOrderDetails(data.order);
+					const order = data.order;
+					if (!order?.status) return;
+
+					setOrderDetails(order);
 
 					// If order is already PAID, jump to pickup
 					if (
-						data.order.status === OrderStatus.PAID &&
+						order.status === OrderStatus.PAID &&
 						step === OrderStep.PAYMENT
 					) {
 						onPaymentSuccess();
@@ -81,7 +84,7 @@ export default function OrderSteps({
 							OrderStatus.AWAITING_PICKUP,
 							OrderStatus.PRINTED,
 							OrderStatus.PICKED_UP,
-						].includes(data.order.status) &&
+						].includes(order.status) &&
 						step !== OrderStep.COMPLETE
 					) {
 						onPickupConfirmed();
@@ -102,7 +105,7 @@ export default function OrderSteps({
 				const res = await fetch(`/api/shop/${orderId}`);
 				if (res.ok) {
 					const data = await res.json();
-					if (data.order.status === OrderStatus.PAID) {
+					if (data.order?.status === OrderStatus.PAID) {
 						clearInterval(interval);
 						setWaitingForStripe(false);
 						onPaymentSuccess();

--- a/components/ordercontainer/OrderSteps.tsx
+++ b/components/ordercontainer/OrderSteps.tsx
@@ -72,10 +72,7 @@ export default function OrderSteps({
 					setOrderDetails(order);
 
 					// If order is already PAID, jump to pickup
-					if (
-						order.status === OrderStatus.PAID &&
-						step === OrderStep.PAYMENT
-					) {
+					if (order.status === OrderStatus.PAID && step === OrderStep.PAYMENT) {
 						onPaymentSuccess();
 					}
 					// If already has a timeslot, jump to complete

--- a/lib/payload.ts
+++ b/lib/payload.ts
@@ -2,17 +2,37 @@ import type { Payload } from "payload";
 import { getPayload } from "payload";
 import configPromise from "../payload.config";
 
-let cachedPayload: Payload | null = null;
+/** Timeout (ms) for Payload initialisation — prevents Workers from hanging. */
+const INIT_TIMEOUT_MS = 15_000;
+
+/**
+ * Eagerly start Payload initialization at module-load time.
+ *
+ * On Cloudflare Workers the first request after a cold start must wait for
+ * Payload + MongoDB to initialise. By kicking this off at import time the
+ * connection is established in parallel with request routing, which greatly
+ * reduces (or eliminates) the cold-start penalty for the first request.
+ *
+ * A timeout wrapper ensures the Worker never hangs indefinitely if the
+ * database is unreachable.
+ */
+const payloadPromise: Promise<Payload> = Promise.race([
+	getPayload({ config: configPromise }),
+	new Promise<never>((_, reject) =>
+		setTimeout(
+			() => reject(new Error("Payload initialization timed out")),
+			INIT_TIMEOUT_MS,
+		),
+	),
+]);
 
 /**
  * Returns a cached Payload CMS client instance.
  * Uses the Payload Local API for server-side data fetching.
+ *
+ * The first call awaits the eagerly-started initialisation promise;
+ * subsequent calls return the already-resolved instance immediately.
  */
 export const getPayloadClient = async (): Promise<Payload> => {
-	if (cachedPayload) {
-		return cachedPayload;
-	}
-
-	cachedPayload = await getPayload({ config: configPromise });
-	return cachedPayload;
+	return payloadPromise;
 };

--- a/payload.config.ts
+++ b/payload.config.ts
@@ -22,6 +22,14 @@ export default buildConfig({
 	secret: process.env.PAYLOAD_SECRET || "CHANGE-ME-IN-PRODUCTION",
 	db: mongooseAdapter({
 		url: process.env.DATABASE_URI || process.env.MONGODB_URI || "",
+		connectOptions: {
+			// Prevent indefinite hangs on Cloudflare Workers (stateless runtime).
+			// Without these, a slow or unreachable MongoDB will cause the Worker
+			// to hang until Cloudflare cancels the request.
+			serverSelectionTimeoutMS: 5000,
+			connectTimeoutMS: 5000,
+			socketTimeoutMS: 10000,
+		},
 	}),
 	editor: lexicalEditor(),
 	collections: [Users, Customers, Orders, Timeslots, AboutSections, Media],


### PR DESCRIPTION
## Problem
Three production errors on Cloudflare Workers:
1. `TypeError: Cannot read properties of undefined (reading 'includes')` on `GET /order`
2. Worker hang (canceled by runtime) on `GET /admin/login`
3. Worker hang on `GET /api/media/file/...`

## Root Causes
- **`.includes()` crash:** API responses with missing `order` data were accessed without null checks in `OrderSteps.tsx` and `OrderContainer.tsx`
- **Worker hangs:** MongoDB connection via Mongoose had no timeouts configured, causing indefinite blocking when DB was slow/unreachable on cold starts. Payload initialization was also lazy (only triggered on first request), maximizing cold-start latency.

## Fixes
| File | Change |
|------|--------|
| `payload.config.ts` | Add `connectOptions` with `serverSelectionTimeoutMS`, `connectTimeoutMS`, `socketTimeoutMS` |
| `lib/payload.ts` | Eagerly initialize Payload at module-load time with 15s timeout guard |
| `components/ordercontainer/OrderSteps.tsx` | Guard `data.order` with null checks before accessing `.status` |
| `components/ordercontainer/OrderContainer.tsx` | Guard `data.order` with null checks in resume order flow |