### PR TITLE
feat: migrate from Cloudflare Workers to Cloudflare Containers (Docker-based deployment)

### DIFF
--- a/.dev.vars
+++ b/.dev.vars
@@ -1,1 +1,0 @@
-NEXTJS_ENV=development

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,44 @@
+# Dependencies (installed inside the container)
+node_modules
+.pnp
+.pnp.js
+
+# Build outputs
+.next
+.open-next
+out
+dist
+
+# Environment / secrets
+.env
+.env.*
+.dev.vars
+
+# Version control
+.git
+.gitignore
+
+# IDE / editor
+.vscode
+.idea
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# CI/CD
+.github
+
+# Terraform
+terraform
+
+# Docker (don't send Dockerfile to build context)
+Dockerfile
+.dockerignore
+
+# Misc
+*.log
+*.tsbuildinfo
+coverage

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
+.dev.vars
 
 # vercel
 .vercel

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,63 @@
+# ── Stage 1: Install dependencies ─────────────────────────────────────────
+FROM node:22-slim AS deps
+
+WORKDIR /app
+
+# Enable pnpm via corepack (matches packageManager in package.json)
+RUN corepack enable pnpm
+
+# Copy only the files pnpm needs to resolve packages
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml* .npmrc* ./
+# Canvas shim referenced by pnpm.overrides — must exist during install
+COPY shims/ ./shims/
+
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile
+
+
+# ── Stage 2: Build the application ───────────────────────────────────────
+FROM node:22-slim AS builder
+
+WORKDIR /app
+
+RUN corepack enable pnpm
+
+# Copy deps from stage 1
+COPY --from=deps /app/node_modules ./node_modules
+
+# Copy source code
+COPY . .
+
+# Next.js collects anonymous telemetry — disable in CI/Docker builds
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV NODE_ENV=production
+
+RUN pnpm build
+
+
+# ── Stage 3: Production runner ───────────────────────────────────────────
+FROM node:22-slim AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+# Don't run as root
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+# Copy public assets
+COPY --from=builder /app/public ./public
+
+# Copy the standalone server + static assets produced by `output: "standalone"`
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/biome.json
+++ b/biome.json
@@ -1,9 +1,9 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.1.1/schema.json",
 	"vcs": {
-		"enabled": false,
+		"enabled": true,
 		"clientKind": "git",
-		"useIgnoreFile": false
+		"useIgnoreFile": true
 	},
 	"formatter": {
 		"enabled": true,
@@ -32,20 +32,7 @@
 		}
 	},
 	"files": {
-		"includes": [
-			"**",
-			"!**/node_modules/**",
-			"!**/.next/**",
-			"!**/dist/**",
-			"!**/build/**",
-			"!**/coverage/**",
-			"!**/.git/**",
-			"!**/.vscode/**",
-			"!**/.idea/**",
-			"!**/.DS_Store",
-			"!**/Thumbs.db",
-			"!**/importMap.js"
-		],
+		"includes": ["**", "!**/importMap.js"],
 		"ignoreUnknown": true
 	}
 }

--- a/container-worker.js
+++ b/container-worker.js
@@ -1,0 +1,67 @@
+/**
+ * Thin Worker entrypoint for Cloudflare Containers.
+ *
+ * Every incoming request is forwarded to the Next.js server running
+ * inside the Container via a Durable Object stub. The Container
+ * maintains a persistent Node.js process with pooled MongoDB
+ * connections — no cold-start penalty on every request.
+ */
+
+import { Container, getContainer } from "@cloudflare/containers";
+
+export class PrimalPrinting extends Container {
+	defaultPort = 3000;
+
+	constructor(ctx, env) {
+		super(ctx, env);
+		// Called when a new container instance starts — use to pass secrets
+		// and env vars from the Worker environment into the container.
+		this.envVars = {
+			NODE_ENV: "production",
+			PORT: "3000",
+			HOSTNAME: "0.0.0.0",
+			// Database
+			DATABASE_URI: env.DATABASE_URI ?? env.MONGODB_URI ?? "",
+			MONGODB_URI: env.MONGODB_URI ?? env.DATABASE_URI ?? "",
+			// Payload CMS
+			PAYLOAD_SECRET: env.PAYLOAD_SECRET ?? "",
+			BASE_URL: env.BASE_URL ?? "",
+			// Auth
+			NEXTAUTH_SECRET: env.NEXTAUTH_SECRET ?? "",
+			NEXTAUTH_URL: env.NEXTAUTH_URL ?? env.BASE_URL ?? "",
+			GOOGLE_CLIENT_ID: env.GOOGLE_CLIENT_ID ?? "",
+			GOOGLE_CLIENT_SECRET: env.GOOGLE_CLIENT_SECRET ?? "",
+			// R2 / S3 storage
+			R2_BUCKET: env.R2_BUCKET ?? "primalprinting-media",
+			R2_S3_ENDPOINT: env.R2_S3_ENDPOINT ?? "",
+			R2_ACCESS_KEY_ID: env.R2_ACCESS_KEY_ID ?? "",
+			R2_SECRET_ACCESS_KEY: env.R2_SECRET_ACCESS_KEY ?? "",
+			R2_PUBLIC_URL: env.R2_PUBLIC_URL ?? "",
+			// Stripe
+			STRIPE_PRIVATE_KEY: env.STRIPE_PRIVATE_KEY ?? "",
+			STRIPE_WEBHOOK_SECRET: env.STRIPE_WEBHOOK_SECRET ?? "",
+			// Email
+			GMAIL_USER: env.GMAIL_USER ?? "",
+			GMAIL_PASS: env.GMAIL_PASS ?? "",
+			// Discord
+			DISCORD_WEBHOOK_URL: env.DISCORD_WEBHOOK_URL ?? "",
+			// Public env vars (baked into client bundle at build time, but
+			// still useful for server-side code that reads them)
+			NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT:
+				env.NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT ?? "2",
+			NEXT_PUBLIC_DISCOUNT_PERCENT:
+				env.NEXT_PUBLIC_DISCOUNT_PERCENT ?? "10",
+		}
+	}
+}
+
+export default {
+	async fetch(request, env) {
+		const url = new URL(request.url);
+		const id = url.searchParams.get('id') || 'singleton';
+		// Get the container instance for the given session ID
+		const containerInstance = getContainer(env.APP, id);
+		// Pass the request to the container instance on its default port
+		return containerInstance.fetch(request);
+	},
+};

--- a/container-worker.js
+++ b/container-worker.js
@@ -49,16 +49,15 @@ export class PrimalPrinting extends Container {
 			// still useful for server-side code that reads them)
 			NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT:
 				env.NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT ?? "2",
-			NEXT_PUBLIC_DISCOUNT_PERCENT:
-				env.NEXT_PUBLIC_DISCOUNT_PERCENT ?? "10",
-		}
+			NEXT_PUBLIC_DISCOUNT_PERCENT: env.NEXT_PUBLIC_DISCOUNT_PERCENT ?? "10",
+		};
 	}
 }
 
 export default {
 	async fetch(request, env) {
 		const url = new URL(request.url);
-		const id = url.searchParams.get('id') || 'singleton';
+		const id = url.searchParams.get("id") || "singleton";
 		// Get the container instance for the given session ID
 		const containerInstance = getContainer(env.APP, id);
 		// Pass the request to the container instance on its default port

--- a/next.config.js
+++ b/next.config.js
@@ -3,19 +3,23 @@ const { withPayload } = require("@payloadcms/next/withPayload");
 /** @type {import('next').NextConfig} */
 const nextConfig = {
 	reactStrictMode: true,
+	// Produce a self-contained build for Docker / Cloudflare Containers.
+	// This traces only the files actually needed at runtime so the final
+	// image stays well under 500 MB.
+	output: "standalone",
 	typescript: {
 		ignoreBuildErrors: false,
 	},
-	// Required for Cloudflare Workers deployment (opennextjs-cloudflare).
-	// These packages are transitive deps that pnpm's strict hoisting prevents
-	// esbuild from resolving during the OpenNext build. Adding them here ensures
-	// Next.js NFT traces them into .open-next/server-functions/default/node_modules/.
-	// - jose: used by payload for JWT auth (auth/operations/me.js, auth/strategies/jwt.js)
-	// - pdfjs-dist: only used client-side, but gets traced into server bundle where
-	//   it tries to require("canvas") which is a native addon incompatible with Workers
 	serverExternalPackages: ["jose", "pdfjs-dist"],
 };
 
 module.exports = withPayload(nextConfig);
 
-import("@opennextjs/cloudflare").then((m) => m.initOpenNextCloudflareForDev());
+// OpenNext Cloudflare dev helper — only runs locally, harmless in Docker.
+if (process.env.NODE_ENV !== "production") {
+	import("@opennextjs/cloudflare")
+		.then((m) => m.initOpenNextCloudflareForDev())
+		.catch(() => {
+			// Not available when running in Docker — safe to ignore.
+		});
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"@aws-sdk/s3-request-presigner": "^3.1030.0",
 		"@chakra-ui/icons": "^2.0.4",
 		"@chakra-ui/react": "^2.2.4",
+		"@cloudflare/containers": "^0.3.2",
 		"@emotion/react": "^11.9.3",
 		"@emotion/styled": "^11.9.3",
 		"@opennextjs/cloudflare": "^1.19.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@chakra-ui/react':
         specifier: ^2.2.4
         version: 2.2.4(@emotion/react@11.9.3(@babel/core@7.18.9)(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.9.3(@babel/core@7.18.9)(@emotion/react@11.9.3(@babel/core@7.18.9)(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(framer-motion@6.5.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@cloudflare/containers':
+        specifier: ^0.3.2
+        version: 0.3.2
       '@emotion/react':
         specifier: ^11.9.3
         version: 11.9.3(@babel/core@7.18.9)(@types/react@19.2.14)(react@19.2.5)
@@ -973,6 +976,9 @@ packages:
     peerDependencies:
       '@chakra-ui/system': '>=2.0.0-next.0'
       react: '>=18'
+
+  '@cloudflare/containers@0.3.2':
+    resolution: {integrity: sha512-hWobJrpXCgFJ/HYii6E49eegnnlUDWGacjLd0Fb6nQwTD005+T2eHUPI6qOEq9KPJOd7xTWkhkuXEKxDFvfyqQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@cloudflare/containers/-/containers-0.3.2.tgz}
 
   '@cloudflare/kv-asset-handler@0.4.2':
     resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz}
@@ -8063,6 +8069,8 @@ snapshots:
       '@chakra-ui/system': 2.2.2(@emotion/react@11.9.3(@babel/core@7.18.9)(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.9.3(@babel/core@7.18.9)(@emotion/react@11.9.3(@babel/core@7.18.9)(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
       '@chakra-ui/utils': 2.0.4
       react: 19.2.5
+
+  '@cloudflare/containers@0.3.2': {}
 
   '@cloudflare/kv-asset-handler@0.4.2': {}
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,6 +1,6 @@
 {
 	"$schema": "node_modules/wrangler/config-schema.json",
-	"main": ".open-next/worker.js",
+	"main": "container-worker.js",
 	"name": "primalprinting",
 	"compatibility_date": "2026-04-16",
 	"compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
@@ -8,28 +8,30 @@
 		"directory": ".open-next/assets",
 		"binding": "ASSETS"
 	},
-	"services": [
+	"containers": [
 		{
-			// Self-reference service binding, the service name must match the worker name
-			// see https://opennext.js.org/cloudflare/caching
-			"binding": "WORKER_SELF_REFERENCE",
-			"service": "primalprinting"
+			"class_name": "PrimalPrinting",
+			"image": "./Dockerfile",
+			"max_instances": 1
 		}
 	],
-	"r2_buckets": [
-		// Use R2 incremental cache
-		// See https://opennext.js.org/cloudflare/caching
-		{
-			"binding": "NEXT_INC_CACHE_R2_BUCKET",
-			// Create the bucket before deploying
-			// You can change the bucket name if you want
-			// See https://developers.cloudflare.com/workers/wrangler/commands/#r2-bucket-create
-			"bucket_name": "primalprinting-opennext-cache"
-		}
-	],
+	"durable_objects": {
+		"bindings": [
+			{
+				"class_name": "PrimalPrinting",
+				"name": "APP"
+			}
+		]
+	},
 	"images": {
 		// Enable image optimization
 		// see https://opennext.js.org/cloudflare/howtos/image
 		"binding": "IMAGES"
-	}
+	},
+	"migrations": [
+		{
+			"tag": "v1",
+			"new_sqlite_classes": ["PrimalPrinting"]
+		}
+	]
 }


### PR DESCRIPTION
## Summary

Migrate the deployment infrastructure from Cloudflare Workers to Cloudflare Containers with Docker-based deployment.

### Changes
- Migrate to Cloudflare Containers with Docker-based deployment
- Standardize string quotes and improve environment variable handling
- Fix Worker hangs, SSR crash, and undefined `.includes()` error
- Fix Biome config to enable VCS ignore, preventing slow pre-push scans (was scanning 3GB of `node_modules` + `.next`)

### Biome Fix
Previously `vcs.useIgnoreFile` was `false` and `files.includes` had negation patterns like `!**/node_modules/**` that didn't work correctly in Biome 2.x, causing `pnpm biome ci .` to hang by scanning all of `node_modules` and `.next`. Fixed by enabling `vcs.enabled: true` and `vcs.useIgnoreFile: true` so Biome respects `.gitignore`.