### PR TITLE
refactor: use cloudflare:workers env import instead of constructor

### DIFF
--- a/container-worker.js
+++ b/container-worker.js
@@ -7,51 +7,49 @@
  * connections — no cold-start penalty on every request.
  */
 
+import { env } from "cloudflare:workers";
 import { Container, getContainer } from "@cloudflare/containers";
 
 export class PrimalPrinting extends Container {
 	defaultPort = 3000;
 
-	constructor(ctx, env) {
-		super(ctx, env);
 		// Called when a new container instance starts — use to pass secrets
 		// and env vars from the Worker environment into the container.
-		this.envVars = {
-			NODE_ENV: "production",
-			PORT: "3000",
-			HOSTNAME: "0.0.0.0",
-			// Database
-			DATABASE_URI: env.DATABASE_URI ?? env.MONGODB_URI ?? "",
-			MONGODB_URI: env.MONGODB_URI ?? env.DATABASE_URI ?? "",
-			// Payload CMS
-			PAYLOAD_SECRET: env.PAYLOAD_SECRET ?? "",
-			BASE_URL: env.BASE_URL ?? "",
-			// Auth
-			NEXTAUTH_SECRET: env.NEXTAUTH_SECRET ?? "",
-			NEXTAUTH_URL: env.NEXTAUTH_URL ?? env.BASE_URL ?? "",
-			GOOGLE_CLIENT_ID: env.GOOGLE_CLIENT_ID ?? "",
-			GOOGLE_CLIENT_SECRET: env.GOOGLE_CLIENT_SECRET ?? "",
-			// R2 / S3 storage
-			R2_BUCKET: env.R2_BUCKET ?? "primalprinting-media",
-			R2_S3_ENDPOINT: env.R2_S3_ENDPOINT ?? "",
-			R2_ACCESS_KEY_ID: env.R2_ACCESS_KEY_ID ?? "",
-			R2_SECRET_ACCESS_KEY: env.R2_SECRET_ACCESS_KEY ?? "",
-			R2_PUBLIC_URL: env.R2_PUBLIC_URL ?? "",
-			// Stripe
-			STRIPE_PRIVATE_KEY: env.STRIPE_PRIVATE_KEY ?? "",
-			STRIPE_WEBHOOK_SECRET: env.STRIPE_WEBHOOK_SECRET ?? "",
-			// Email
-			GMAIL_USER: env.GMAIL_USER ?? "",
-			GMAIL_PASS: env.GMAIL_PASS ?? "",
-			// Discord
-			DISCORD_WEBHOOK_URL: env.DISCORD_WEBHOOK_URL ?? "",
-			// Public env vars (baked into client bundle at build time, but
-			// still useful for server-side code that reads them)
-			NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT:
-				env.NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT ?? "2",
-			NEXT_PUBLIC_DISCOUNT_PERCENT: env.NEXT_PUBLIC_DISCOUNT_PERCENT ?? "10",
-		};
-	}
+	envVars = {
+		NODE_ENV: "production",
+		PORT: "3000",
+		HOSTNAME: "0.0.0.0",
+		// Database
+		DATABASE_URI: env.DATABASE_URI ?? env.MONGODB_URI ?? "",
+		MONGODB_URI: env.MONGODB_URI ?? env.DATABASE_URI ?? "",
+		// Payload CMS
+		PAYLOAD_SECRET: env.PAYLOAD_SECRET ?? "",
+		BASE_URL: env.BASE_URL ?? "",
+		// Auth
+		NEXTAUTH_SECRET: env.NEXTAUTH_SECRET ?? "",
+		NEXTAUTH_URL: env.NEXTAUTH_URL ?? env.BASE_URL ?? "",
+		GOOGLE_CLIENT_ID: env.GOOGLE_CLIENT_ID ?? "",
+		GOOGLE_CLIENT_SECRET: env.GOOGLE_CLIENT_SECRET ?? "",
+		// R2 / S3 storage
+		R2_BUCKET: env.R2_BUCKET ?? "primalprinting-media",
+		R2_S3_ENDPOINT: env.R2_S3_ENDPOINT ?? "",
+		R2_ACCESS_KEY_ID: env.R2_ACCESS_KEY_ID ?? "",
+		R2_SECRET_ACCESS_KEY: env.R2_SECRET_ACCESS_KEY ?? "",
+		R2_PUBLIC_URL: env.R2_PUBLIC_URL ?? "",
+		// Stripe
+		STRIPE_PRIVATE_KEY: env.STRIPE_PRIVATE_KEY ?? "",
+		STRIPE_WEBHOOK_SECRET: env.STRIPE_WEBHOOK_SECRET ?? "",
+		// Email
+		GMAIL_USER: env.GMAIL_USER ?? "",
+		GMAIL_PASS: env.GMAIL_PASS ?? "",
+		// Discord
+		DISCORD_WEBHOOK_URL: env.DISCORD_WEBHOOK_URL ?? "",
+		// Public env vars (baked into client bundle at build time, but
+		// still useful for server-side code that reads them)
+		NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT:
+			env.NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT ?? "2",
+		NEXT_PUBLIC_DISCOUNT_PERCENT: env.NEXT_PUBLIC_DISCOUNT_PERCENT ?? "10",
+	};
 }
 
 export default {

--- a/container-worker.js
+++ b/container-worker.js
@@ -13,8 +13,8 @@ import { Container, getContainer } from "@cloudflare/containers";
 export class PrimalPrinting extends Container {
 	defaultPort = 3000;
 
-		// Called when a new container instance starts — use to pass secrets
-		// and env vars from the Worker environment into the container.
+	// Called when a new container instance starts — use to pass secrets
+	// and env vars from the Worker environment into the container.
 	envVars = {
 		NODE_ENV: "production",
 		PORT: "3000",


### PR DESCRIPTION
## Summary

Simplifies the `PrimalPrinting` container class by using the module-level `env` import from `cloudflare:workers` instead of accessing it through the constructor.

### Changes
- Import `env` from `cloudflare:workers` at module level
- Convert `envVars` from constructor assignment to a class field
- Remove constructor override, simplifying the `Container` subclass

This is a cleaner pattern that avoids the need to override the constructor just to set environment variables.