### PR TITLE
fix: switch getStaticProps to getServerSideProps to avoid build-time MongoDB errors

### DIFF
--- a/container-worker.js
+++ b/container-worker.js
@@ -7,51 +7,49 @@
  * connections — no cold-start penalty on every request.
  */
 
+import { env } from "cloudflare:workers";
 import { Container, getContainer } from "@cloudflare/containers";
 
 export class PrimalPrinting extends Container {
 	defaultPort = 3000;
 
-	constructor(ctx, env) {
-		super(ctx, env);
 		// Called when a new container instance starts — use to pass secrets
 		// and env vars from the Worker environment into the container.
-		this.envVars = {
-			NODE_ENV: "production",
-			PORT: "3000",
-			HOSTNAME: "0.0.0.0",
-			// Database
-			DATABASE_URI: env.DATABASE_URI ?? env.MONGODB_URI ?? "",
-			MONGODB_URI: env.MONGODB_URI ?? env.DATABASE_URI ?? "",
-			// Payload CMS
-			PAYLOAD_SECRET: env.PAYLOAD_SECRET ?? "",
-			BASE_URL: env.BASE_URL ?? "",
-			// Auth
-			NEXTAUTH_SECRET: env.NEXTAUTH_SECRET ?? "",
-			NEXTAUTH_URL: env.NEXTAUTH_URL ?? env.BASE_URL ?? "",
-			GOOGLE_CLIENT_ID: env.GOOGLE_CLIENT_ID ?? "",
-			GOOGLE_CLIENT_SECRET: env.GOOGLE_CLIENT_SECRET ?? "",
-			// R2 / S3 storage
-			R2_BUCKET: env.R2_BUCKET ?? "primalprinting-media",
-			R2_S3_ENDPOINT: env.R2_S3_ENDPOINT ?? "",
-			R2_ACCESS_KEY_ID: env.R2_ACCESS_KEY_ID ?? "",
-			R2_SECRET_ACCESS_KEY: env.R2_SECRET_ACCESS_KEY ?? "",
-			R2_PUBLIC_URL: env.R2_PUBLIC_URL ?? "",
-			// Stripe
-			STRIPE_PRIVATE_KEY: env.STRIPE_PRIVATE_KEY ?? "",
-			STRIPE_WEBHOOK_SECRET: env.STRIPE_WEBHOOK_SECRET ?? "",
-			// Email
-			GMAIL_USER: env.GMAIL_USER ?? "",
-			GMAIL_PASS: env.GMAIL_PASS ?? "",
-			// Discord
-			DISCORD_WEBHOOK_URL: env.DISCORD_WEBHOOK_URL ?? "",
-			// Public env vars (baked into client bundle at build time, but
-			// still useful for server-side code that reads them)
-			NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT:
-				env.NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT ?? "2",
-			NEXT_PUBLIC_DISCOUNT_PERCENT: env.NEXT_PUBLIC_DISCOUNT_PERCENT ?? "10",
-		};
-	}
+	envVars = {
+		NODE_ENV: "production",
+		PORT: "3000",
+		HOSTNAME: "0.0.0.0",
+		// Database
+		DATABASE_URI: env.DATABASE_URI ?? env.MONGODB_URI ?? "",
+		MONGODB_URI: env.MONGODB_URI ?? env.DATABASE_URI ?? "",
+		// Payload CMS
+		PAYLOAD_SECRET: env.PAYLOAD_SECRET ?? "",
+		BASE_URL: env.BASE_URL ?? "",
+		// Auth
+		NEXTAUTH_SECRET: env.NEXTAUTH_SECRET ?? "",
+		NEXTAUTH_URL: env.NEXTAUTH_URL ?? env.BASE_URL ?? "",
+		GOOGLE_CLIENT_ID: env.GOOGLE_CLIENT_ID ?? "",
+		GOOGLE_CLIENT_SECRET: env.GOOGLE_CLIENT_SECRET ?? "",
+		// R2 / S3 storage
+		R2_BUCKET: env.R2_BUCKET ?? "primalprinting-media",
+		R2_S3_ENDPOINT: env.R2_S3_ENDPOINT ?? "",
+		R2_ACCESS_KEY_ID: env.R2_ACCESS_KEY_ID ?? "",
+		R2_SECRET_ACCESS_KEY: env.R2_SECRET_ACCESS_KEY ?? "",
+		R2_PUBLIC_URL: env.R2_PUBLIC_URL ?? "",
+		// Stripe
+		STRIPE_PRIVATE_KEY: env.STRIPE_PRIVATE_KEY ?? "",
+		STRIPE_WEBHOOK_SECRET: env.STRIPE_WEBHOOK_SECRET ?? "",
+		// Email
+		GMAIL_USER: env.GMAIL_USER ?? "",
+		GMAIL_PASS: env.GMAIL_PASS ?? "",
+		// Discord
+		DISCORD_WEBHOOK_URL: env.DISCORD_WEBHOOK_URL ?? "",
+		// Public env vars (baked into client bundle at build time, but
+		// still useful for server-side code that reads them)
+		NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT:
+			env.NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT ?? "2",
+		NEXT_PUBLIC_DISCOUNT_PERCENT: env.NEXT_PUBLIC_DISCOUNT_PERCENT ?? "10",
+	};
 }
 
 export default {

--- a/container-worker.js
+++ b/container-worker.js
@@ -13,8 +13,8 @@ import { Container, getContainer } from "@cloudflare/containers";
 export class PrimalPrinting extends Container {
 	defaultPort = 3000;
 
-		// Called when a new container instance starts — use to pass secrets
-		// and env vars from the Worker environment into the container.
+	// Called when a new container instance starts — use to pass secrets
+	// and env vars from the Worker environment into the container.
 	envVars = {
 		NODE_ENV: "production",
 		PORT: "3000",

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -5,7 +5,10 @@ import Footer from "../components/footer/Footer";
 import NavBar from "../components/navbar/NavBar";
 import { getPayloadClient } from "../lib/payload";
 
-export async function getStaticProps() {
+export async function getServerSideProps({ res }: { res: import("http").ServerResponse }) {
+	// Cache at the CDN edge for 24 h, serve stale while revalidating for another 24 h
+	res.setHeader("Cache-Control", "public, s-maxage=86400, stale-while-revalidate=86400");
+
 	try {
 		const payload = await getPayloadClient();
 		const contactInfo = await payload.findGlobal({
@@ -15,7 +18,6 @@ export async function getStaticProps() {
 			props: {
 				contactInfo: JSON.parse(JSON.stringify(contactInfo)),
 			},
-			revalidate: 24 * 60 * 60,
 		};
 	} catch (_error) {
 		console.log("could not fetch data");

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -1,9 +1,9 @@
 import { Box, Heading, Stack, Text } from "@chakra-ui/react";
 import type { NextPage } from "next";
 import Head from "next/head";
+import { getPayloadClient } from "@/lib/payload";
 import Footer from "../components/footer/Footer";
 import NavBar from "../components/navbar/NavBar";
-import { getPayloadClient } from "@/lib/payload";
 
 export async function getServerSideProps({
 	res,

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -3,11 +3,18 @@ import type { NextPage } from "next";
 import Head from "next/head";
 import Footer from "../components/footer/Footer";
 import NavBar from "../components/navbar/NavBar";
-import { getPayloadClient } from "../lib/payload";
+import { getPayloadClient } from "@/lib/payload";
 
-export async function getServerSideProps({ res }: { res: import("http").ServerResponse }) {
+export async function getServerSideProps({
+	res,
+}: {
+	res: import("http").ServerResponse;
+}) {
 	// Cache at the CDN edge for 24 h, serve stale while revalidating for another 24 h
-	res.setHeader("Cache-Control", "public, s-maxage=86400, stale-while-revalidate=86400");
+	res.setHeader(
+		"Cache-Control",
+		"public, s-maxage=86400, stale-while-revalidate=86400",
+	);
 
 	try {
 		const payload = await getPayloadClient();

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,11 +6,18 @@ import Footer from "../components/footer/Footer";
 import IntroAnimation from "../components/intro/IntroAnimation";
 import NavBar from "../components/navbar/NavBar";
 import WhatNextDiv from "../components/whatnextdiv/WhatNextDiv";
-import { getPayloadClient } from "../lib/payload";
+import { getPayloadClient } from "@/lib/payload";
 
-export async function getServerSideProps({ res }: { res: import("http").ServerResponse }) {
+export async function getServerSideProps({
+	res,
+}: {
+	res: import("http").ServerResponse;
+}) {
 	// Cache at the CDN edge for 1 h, serve stale while revalidating for another 1 h
-	res.setHeader("Cache-Control", "public, s-maxage=3600, stale-while-revalidate=3600");
+	res.setHeader(
+		"Cache-Control",
+		"public, s-maxage=3600, stale-while-revalidate=3600",
+	);
 
 	try {
 		const payload = await getPayloadClient();

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,11 +2,11 @@ import { Box, Divider, Heading } from "@chakra-ui/react";
 import { RichText } from "@payloadcms/richtext-lexical/react";
 import type { NextPage } from "next";
 import Head from "next/head";
+import { getPayloadClient } from "@/lib/payload";
 import Footer from "../components/footer/Footer";
 import IntroAnimation from "../components/intro/IntroAnimation";
 import NavBar from "../components/navbar/NavBar";
 import WhatNextDiv from "../components/whatnextdiv/WhatNextDiv";
-import { getPayloadClient } from "@/lib/payload";
 
 export async function getServerSideProps({
 	res,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,7 +8,10 @@ import NavBar from "../components/navbar/NavBar";
 import WhatNextDiv from "../components/whatnextdiv/WhatNextDiv";
 import { getPayloadClient } from "../lib/payload";
 
-export async function getStaticProps() {
+export async function getServerSideProps({ res }: { res: import("http").ServerResponse }) {
+	// Cache at the CDN edge for 1 h, serve stale while revalidating for another 1 h
+	res.setHeader("Cache-Control", "public, s-maxage=3600, stale-while-revalidate=3600");
+
 	try {
 		const payload = await getPayloadClient();
 
@@ -26,7 +29,6 @@ export async function getStaticProps() {
 				sections: JSON.parse(JSON.stringify(sections)),
 				contactInfo: JSON.parse(JSON.stringify(contactInfo)),
 			},
-			revalidate: 60 * 60,
 		};
 	} catch (error) {
 		console.log(error);


### PR DESCRIPTION
## Problem

Pages using `getStaticProps` (`contact.tsx`, `index.tsx`) attempted to connect to MongoDB during `pnpm build` inside the Docker builder stage. At build time, `DATABASE_URI` is not available — env vars are only injected at container runtime by the Cloudflare Worker (`container-worker.js`).

This caused the deployment to fail with:
```
Error: cannot connect to MongoDB. Details: Invalid scheme, expected connection string to start with "mongodb://" or "mongodb+srv://"
```

## Solution

- **`pages/contact.tsx`**: `getStaticProps` → `getServerSideProps`
- **`pages/index.tsx`**: `getStaticProps` → `getServerSideProps`
- Added `Cache-Control` headers (`s-maxage` + `stale-while-revalidate`) to preserve CDN caching equivalent to the old `revalidate` intervals:
  - **Contact**: 24 hours (was `revalidate: 86400`)
  - **Index**: 1 hour (was `revalidate: 3600`)

## Why this works

`getStaticProps` runs at **build time** (no env vars in Docker builder) and then revalidates at runtime.
`getServerSideProps` runs only at **request time** (env vars available via `container-worker.js` → container runtime).

The `Cache-Control` headers ensure Cloudflare's CDN caches the responses, so performance is equivalent to the old ISR setup.