### PR TITLE
fix: inject NEXT_PUBLIC_* env vars at container startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,70 @@
+# Agent Instructions
+
+## Environment Variable Sync
+
+Ensure all environment variables are defined, consistent, and up-to-date across **every** touchpoint in the project. Apply this rule whenever adding, renaming, or removing an env var.
+
+### Process
+
+When an env var change is requested:
+
+1. **Discover all touchpoints** — scan the project for every file that references env vars.
+2. **Apply changes holistically** — update every touchpoint in a single pass.
+3. **Verify consistency** — confirm no stale names, missing entries, or duplicates remain.
+
+### Discovery: finding env var touchpoints
+
+Search the project for all locations that define, declare, or consume environment variables:
+
+#### Source code
+- Grep for `process.env.`, `import.meta.env.`, `env.`, `os.environ`, `os.Getenv`, `System.getenv`, or equivalent patterns for the project's language/framework.
+- Check for typed env declarations (e.g. `env.d.ts`, `.env.d.ts`, `environment.d.ts`, `config.ts`, `settings.py`, etc.).
+
+#### Configuration & infrastructure
+- **Env files**: `.env`, `.env.local`, `.env.example`, `.env.production`, `.env.development`, `.env.test`, etc.
+- **Docker**: `Dockerfile` (`ENV`, `ARG`), `docker-compose.yml` (`environment:`, `env_file:`), entrypoint scripts.
+- **CI/CD**: GitHub Actions (`.github/workflows/*.yml`), GitLab CI, Bitbucket Pipelines, etc. — look for `env:` blocks and secret references.
+- **IaC**: Terraform (`variables.tf`, `*.tfvars`), CloudFormation, Pulumi, etc.
+- **Platform config**: `wrangler.toml`/`wrangler.jsonc` (Cloudflare), `vercel.json`, `netlify.toml`, `app.yaml` (GCP), `fly.toml`, etc.
+- **Container orchestration**: Kubernetes manifests (`env:`, `envFrom:`, ConfigMaps, Secrets), Helm `values.yaml`.
+- **Worker/edge entrypoints**: Files that pass env vars from a runtime into a container or subprocess (e.g. Cloudflare Container workers, Lambda handlers).
+
+#### Client-side env vars (framework-specific)
+- **Next.js**: `NEXT_PUBLIC_*` — inlined at build time, needs special handling in Docker (placeholder + entrypoint replacement).
+- **Vite**: `VITE_*` — same build-time inlining concern.
+- **Create React App**: `REACT_APP_*` — same concern.
+- If the project uses Docker, check for a placeholder/entrypoint pattern and keep it in sync.
+
+### Rules
+
+1. **One canonical name per value.** Never maintain two separate secrets/vars that hold the same value. If compatibility aliases are needed, derive them from the canonical var in a single location.
+
+2. **Client-exposed vars** (e.g. `NEXT_PUBLIC_*`, `VITE_*`) that are inlined at build time need special handling in Docker:
+   - Placeholder `ENV` in the Dockerfile build stage.
+   - Entrypoint script replacement entry to swap placeholders with real values at container startup.
+
+3. **Server-only vars** only need entries in the type declarations, runtime config, and env files — no build-time placeholder pipeline.
+
+4. **When removing a var**, check every discovered touchpoint and remove from each.
+
+5. **When renaming a var**, treat it as a remove + add. Update all touchpoints and note the rename in the PR/commit description so deployment configs (cloud dashboards, CI secrets, etc.) can be updated.
+
+6. **Defaults** should be consistent — if the code falls back to `"2"`, the entrypoint script default, Docker placeholder default, and env file value should all agree.
+
+### Checklist
+
+After discovering the project's specific touchpoints, use a checklist like this (adapt to the project):
+
+```
+- [ ] Type declarations (e.g. env.d.ts) — added/updated/removed
+- [ ] Runtime config / worker entrypoint — added/updated/removed
+- [ ] Dockerfile — placeholder ENV added/removed (client-exposed vars only)
+- [ ] Docker entrypoint script — replacement entry added/removed (client-exposed vars only)
+- [ ] Local env file (.env.local / .env) — added/updated/removed
+- [ ] Example env file (.env.example) — added/updated/removed
+- [ ] CI/CD workflows — secret references added/updated/removed
+- [ ] IaC (Terraform, etc.) — variable added/updated/removed (if applicable)
+- [ ] Platform config (wrangler, vercel.json, etc.) — added/updated/removed
+- [ ] No duplicate/alias env vars introduced
+- [ ] Defaults are consistent across all touchpoints
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,14 @@ COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NODE_ENV=production
 
+# Placeholders for NEXT_PUBLIC_* vars — Next.js inlines these into the client
+# bundle at build time. The entrypoint script (docker-entrypoint.sh) replaces
+# them with real values at container startup, keeping the image env-agnostic.
+ENV NEXT_PUBLIC_BASE_URL="__NEXT_PUBLIC_BASE_URL__"
+ENV NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="__NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY__"
+ENV NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT="__NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT__"
+ENV NEXT_PUBLIC_DISCOUNT_PERCENT="__NEXT_PUBLIC_DISCOUNT_PERCENT__"
+
 RUN pnpm build
 
 
@@ -56,8 +64,14 @@ COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
+# Entrypoint script that replaces NEXT_PUBLIC_* placeholders in the
+# compiled client JS with real env var values at container startup.
+COPY --chown=nextjs:nodejs docker-entrypoint.sh ./
+RUN chmod +x docker-entrypoint.sh
+
 USER nextjs
 
 EXPOSE 3000
 
+ENTRYPOINT ["./docker-entrypoint.sh"]
 CMD ["node", "server.js"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -e
+
+# ── Replace NEXT_PUBLIC_* placeholders with real env var values ────────────
+#
+# Next.js inlines NEXT_PUBLIC_* values into the client bundle at build time.
+# The Dockerfile sets unique placeholder strings (e.g. __NEXT_PUBLIC_BASE_URL__)
+# so they end up in the compiled JS. This script replaces those placeholders
+# with the actual runtime env var values before the server starts, keeping
+# the Docker image environment-agnostic.
+
+# Directory containing the built JS files
+SEARCH_DIR="/app/.next"
+
+# Each entry: "PLACEHOLDER|ENV_VAR_NAME|DEFAULT_VALUE"
+REPLACEMENTS="
+__NEXT_PUBLIC_BASE_URL__|NEXT_PUBLIC_BASE_URL|
+__NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY__|NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY|
+__NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT__|NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT|2
+__NEXT_PUBLIC_DISCOUNT_PERCENT__|NEXT_PUBLIC_DISCOUNT_PERCENT|0
+"
+
+for entry in $REPLACEMENTS; do
+  [ -z "$entry" ] && continue
+
+  placeholder=$(echo "$entry" | cut -d'|' -f1)
+  var_name=$(echo "$entry" | cut -d'|' -f2)
+  default_val=$(echo "$entry" | cut -d'|' -f3)
+
+  # Use the env var value if set, otherwise fall back to the default
+  eval "real_val=\${$var_name:-$default_val}"
+
+  # Replace in all JS files under .next
+  find "$SEARCH_DIR" -type f -name '*.js' -exec \
+    sed -i "s|${placeholder}|${real_val}|g" {} +
+done
+
+echo "✅ NEXT_PUBLIC_* placeholders replaced with runtime values"
+
+# Hand off to the original command (node server.js)
+exec "$@"


### PR DESCRIPTION
## Problem

`NEXT_PUBLIC_*` env vars are inlined into the client JS bundle at `next build` time. In our Docker/Cloudflare Container setup, the image is built **without secrets**, so the client bundle bakes in empty values (e.g. `NEXT_PUBLIC_DISCOUNT_PERCENT` shows `0`).

## Solution

**Placeholder + entrypoint replacement pattern:**

1. **Build time** — unique placeholder strings (e.g. `__NEXT_PUBLIC_BASE_URL__`) are set as `ENV` in the Dockerfile builder stage, so `next build` inlines them into the client bundle.

2. **Container startup** — a new `docker-entrypoint.sh` script runs before `node server.js`, finding all `.js` files under `.next/` and `sed`-replacing the placeholders with the real env var values injected by `container-worker.js`.

3. **Result** — a single Docker image that works across all environments. Just change the env vars.

## Env vars handled

| Variable | Default |
|---|---|
| `NEXT_PUBLIC_BASE_URL` | (none) |
| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | (none) |
| `NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT` | `2` |
| `NEXT_PUBLIC_DISCOUNT_PERCENT` | `0` |

## Files changed
- **`Dockerfile`** — added placeholder `ENV`s in build stage, added `ENTRYPOINT` in runner stage
- **`docker-entrypoint.sh`** — new file, handles placeholder → real value replacement at startup