### PR TITLE
fix: add missing env vars to container worker and type declarations

### DIFF
--- a/container-worker.js
+++ b/container-worker.js
@@ -36,14 +36,20 @@ export class PrimalPrinting extends Container {
 		R2_ACCESS_KEY_ID: env.R2_ACCESS_KEY_ID ?? "",
 		R2_SECRET_ACCESS_KEY: env.R2_SECRET_ACCESS_KEY ?? "",
 		R2_PUBLIC_URL: env.R2_PUBLIC_URL ?? "",
+		R2_STAGING_BUCKET: env.R2_STAGING_BUCKET ?? "",
+		R2_PERMANENT_BUCKET: env.R2_PERMANENT_BUCKET ?? "",
 		// Stripe
 		STRIPE_PRIVATE_KEY: env.STRIPE_PRIVATE_KEY ?? "",
 		STRIPE_WEBHOOK_SECRET: env.STRIPE_WEBHOOK_SECRET ?? "",
+		NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY:
+			env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? "",
 		// Email
 		GMAIL_USER: env.GMAIL_USER ?? "",
 		GMAIL_PASS: env.GMAIL_PASS ?? "",
 		// Discord
 		DISCORD_WEBHOOK_URL: env.DISCORD_WEBHOOK_URL ?? "",
+		// Cron
+		CRON_SECRET: env.CRON_SECRET ?? "",
 		// Public env vars (baked into client bundle at build time, but
 		// still useful for server-side code that reads them)
 		NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT:

--- a/env.d.ts
+++ b/env.d.ts
@@ -114,5 +114,19 @@ declare namespace NodeJS {
 		 * Create one via Discord → Server Settings → Integrations → Webhooks.
 		 */
 		DISCORD_WEBHOOK_URL?: string;
+
+		// ── Public / client-side config ──────────────────────────────────
+		/**
+		 * @env NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT
+		 * Minimum number of items required to trigger a discount.
+		 * Defaults to "2" in application code.
+		 */
+		NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT?: string;
+		/**
+		 * @env NEXT_PUBLIC_DISCOUNT_PERCENT
+		 * Discount percentage applied when the minimum items threshold is met.
+		 * Defaults to "0" in application code.
+		 */
+		NEXT_PUBLIC_DISCOUNT_PERCENT?: string;
 	}
 }


### PR DESCRIPTION
## Problem

Several env vars used by the app were not being passed from the Cloudflare Worker into the container, and some were missing from `env.d.ts` type declarations.

The most visible issue: `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` was never forwarded, causing:
```
Uncaught (in promise) IntegrationError: Please call Stripe() with your publishable key. You used an empty string
```

## Changes

### `container-worker.js` — added missing env vars:
| Env Var | Why |
|---|---|
| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Needed by client-side Stripe Elements |
| `CRON_SECRET` | Needed by cron job authentication |
| `R2_STAGING_BUCKET` | Needed by order file upload system |
| `R2_PERMANENT_BUCKET` | Needed by order file storage system |

### `env.d.ts` — added missing type declarations:
| Env Var | Why |
|---|---|
| `NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT` | Used in `lib/utils.ts`, was undeclared |
| `NEXT_PUBLIC_DISCOUNT_PERCENT` | Used in `lib/utils.ts`, was undeclared |