### PR TITLE
fix(wrangler/docker): drop unset Turbo image_vars + strip literal placeholders

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,20 @@ ENV TURBO_TEAM=$TURBO_TEAM \
 # Build via Turbo so the (optional) remote cache is queried before re-running
 # `next build`. Look for "Remote caching enabled" + "cache hit, replaying logs"
 # in the build output to confirm it's working.
-RUN pnpm run build
+#
+# Defensive cleanup: wrangler's `image_vars` substitutes `${VAR}` against the
+# Cloudflare Workers Build env at deploy time, but if the env var is unset
+# wrangler passes through the literal "${VAR}" string instead of an empty
+# value. Strip any such unsubstituted placeholders so Turbo doesn't try to
+# use them as URLs / tokens.
+RUN for v in TURBO_TEAM TURBO_TEAMID TURBO_TOKEN TURBO_API TURBO_REMOTE_CACHE_SIGNATURE_KEY; do \
+      if eval "[ \"\${$v}\" = \"\\\${${v}}\" ]"; then \
+        echo "  unset literal placeholder for \$v"; \
+        unset $v; \
+        export $v=""; \
+      fi; \
+    done && \
+    pnpm run build
 
 # Strip TURBO_TOKEN from the env so it doesn't leak into the runner stage's
 # inherited env or any subsequent layers. (The runner stage starts FROM a

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -15,16 +15,22 @@
 			// substituted by wrangler at deploy time from the build env, so
 			// no secret values are ever committed to this file.
 			//
+			// Only the two vars actually needed for Vercel-hosted Remote
+			// Cache are listed here. If you self-host or sign cache
+			// artefacts, add `"TURBO_API": "${TURBO_API}"` and/or
+			// `"TURBO_REMOTE_CACHE_SIGNATURE_KEY": "${TURBO_REMOTE_CACHE_SIGNATURE_KEY}"`
+			// once those env vars are set in the Cloudflare build env —
+			// referencing an unset env var here makes wrangler pass through
+			// the literal "${TURBO_API}" string, which Turbo then treats as
+			// a (broken) cache URL.
+			//
 			// Configure these in the Cloudflare dashboard:
 			//   Workers & Pages → primalprinting → Settings → Builds →
 			//   Variables and Secrets
-			// (mark TURBO_TOKEN + TURBO_REMOTE_CACHE_SIGNATURE_KEY as "Secret")
+			// (mark TURBO_TOKEN as "Secret")
 			"image_vars": {
 				"TURBO_TEAM": "${TURBO_TEAM}",
-				"TURBO_TEAMID": "${TURBO_TEAMID}",
-				"TURBO_TOKEN": "${TURBO_TOKEN}",
-				"TURBO_API": "${TURBO_API}",
-				"TURBO_REMOTE_CACHE_SIGNATURE_KEY": "${TURBO_REMOTE_CACHE_SIGNATURE_KEY}"
+				"TURBO_TOKEN": "${TURBO_TOKEN}"
 			}
 		}
 	],


### PR DESCRIPTION
## Problem

After merging #56 the Cloudflare deploy now logs:

```
WARNING • Remote caching unavailable (Could not connect to "${TURBO_API}")
```

Even though only `TURBO_TEAM` and `TURBO_TOKEN` are configured in the Cloudflare Workers Build environment.

## Root cause

`wrangler.jsonc` listed every Turbo cache var in `image_vars` using `${VAR}` interpolation:

```jsonc
"image_vars": {
  "TURBO_TEAM": "${TURBO_TEAM}",
  "TURBO_TEAMID": "${TURBO_TEAMID}",
  "TURBO_TOKEN": "${TURBO_TOKEN}",
  "TURBO_API": "${TURBO_API}",
  "TURBO_REMOTE_CACHE_SIGNATURE_KEY": "${TURBO_REMOTE_CACHE_SIGNATURE_KEY}"
}
```

But wrangler **doesn't omit** an `image_var` whose env var is unset — it forwards the literal string `"${TURBO_API}"` through to the docker build as a `--build-arg`. Turbo then takes that string at face value and tries to use it as the remote cache URL, hence the warning.

## Fix

**1. `wrangler.jsonc`** — only list the two vars actually needed for the default Vercel-hosted Remote Cache (`TURBO_TEAM`, `TURBO_TOKEN`). The optional self-hosted / signature-key vars are documented but commented out so adding them back is a one-line change once the corresponding Cloudflare build env vars are set.

**2. `Dockerfile`** — defensive cleanup loop that runs immediately before `pnpm run build`:

```bash
for v in TURBO_TEAM TURBO_TEAMID TURBO_TOKEN TURBO_API TURBO_REMOTE_CACHE_SIGNATURE_KEY; do
  if eval "[ \"\${$v}\" = \"\\\${${v}}\" ]"; then
    echo "  unset literal placeholder for $v";
    unset $v;
    export $v="";
  fi;
done
```

If any of those vars still equal their literal placeholder (`${VAR}`), they're cleared before `turbo run …` sees them. Belt-and-braces against future re-introduction of the same bug.

## Expected after merge

The deploy log should now show:

```
• Remote caching enabled
```

…and on a re-deploy of an unchanged tree:

```
build:next  cache hit, replaying logs
```