### PR TITLE
feat: enable headless asset upload in Cloudflare deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,10 +39,30 @@ ENV NEXT_PUBLIC_BASE_URL="__NEXT_PUBLIC_BASE_URL__"
 ENV NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="__NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY__"
 ENV NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT="__NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT__"
 ENV NEXT_PUBLIC_DISCOUNT_PERCENT="__NEXT_PUBLIC_DISCOUNT_PERCENT__"
-# Asset prefix used by Next.js for /_next/static/* + /_next/image. Replaced
-# at container startup so the same image can target different CDNs/buckets.
-# Defaults to "" so Next falls back to serving assets from the same origin.
-ENV NEXT_PUBLIC_ASSET_PREFIX="__NEXT_PUBLIC_ASSET_PREFIX__"
+# Asset prefix used by Next.js for /_next/static/* + /_next/image.
+#
+# When supplied via wrangler `image_vars`, the real value is baked into the
+# build (so `assetPrefix` resolves to the CDN URL and `pnpm upload-assets`
+# logs the right value in its manifest). The docker-entrypoint.sh placeholder
+# swap also re-applies the runtime value at container startup so the same
+# image can target a different CDN per deploy if needed.
+#
+# Default to the placeholder so local builds without the var still work.
+ARG NEXT_PUBLIC_ASSET_PREFIX="__NEXT_PUBLIC_ASSET_PREFIX__"
+ENV NEXT_PUBLIC_ASSET_PREFIX=$NEXT_PUBLIC_ASSET_PREFIX
+
+# ── R2 credentials for the build-time asset upload ────────────────────────
+# Needed so `pnpm build:headless` (below) can run scripts/upload-assets.mts
+# against the R2 assets bucket. These reuse the same R2 credentials already
+# configured for runtime media access — only the bucket differs.
+ARG R2_ASSETS_BUCKET=""
+ARG R2_S3_ENDPOINT=""
+ARG R2_ACCESS_KEY_ID=""
+ARG R2_SECRET_ACCESS_KEY=""
+ENV R2_ASSETS_BUCKET=$R2_ASSETS_BUCKET \
+    R2_S3_ENDPOINT=$R2_S3_ENDPOINT \
+    R2_ACCESS_KEY_ID=$R2_ACCESS_KEY_ID \
+    R2_SECRET_ACCESS_KEY=$R2_SECRET_ACCESS_KEY
 
 # ── Turborepo Remote Cache (optional) ─────────────────────────────────────
 # Forward the team identity (slug or id), API base URL, and access token as
@@ -86,19 +106,36 @@ ENV TURBO_TEAM=$TURBO_TEAM \
 # wrangler passes through the literal "${VAR}" string instead of an empty
 # value. Strip any such unsubstituted placeholders so Turbo doesn't try to
 # use them as URLs / tokens.
-RUN for v in TURBO_TEAM TURBO_TEAMID TURBO_TOKEN TURBO_API TURBO_REMOTE_CACHE_SIGNATURE_KEY; do \
+#
+# We run `build:headless` rather than `build` when R2 creds are present so
+# the resulting image already has all static assets uploaded to R2. The
+# upload step is gated by Turbo's input/output cache, so on a tree-unchanged
+# re-deploy it's a near-instant no-op (HEAD-skips fingerprinted files).
+#
+# Falls back to a plain `next build` when R2 creds are missing (e.g. local
+# `docker build` without secrets) so local builds still work.
+RUN for v in TURBO_TEAM TURBO_TEAMID TURBO_TOKEN TURBO_API TURBO_REMOTE_CACHE_SIGNATURE_KEY \
+             NEXT_PUBLIC_ASSET_PREFIX R2_ASSETS_BUCKET R2_S3_ENDPOINT R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY; do \
       if eval "[ \"\${$v}\" = \"\\\${${v}}\" ]"; then \
         echo "  unset literal placeholder for \$v"; \
         unset $v; \
         export $v=""; \
       fi; \
     done && \
-    pnpm run build
+    if [ -n "$R2_ASSETS_BUCKET" ] && [ -n "$R2_ACCESS_KEY_ID" ] && [ -n "$R2_SECRET_ACCESS_KEY" ] && [ -n "$R2_S3_ENDPOINT" ]; then \
+      echo "→ Building with headless asset upload (R2_ASSETS_BUCKET=$R2_ASSETS_BUCKET)"; \
+      pnpm run build:headless; \
+    else \
+      echo "→ R2 asset upload credentials not provided — running plain Next build (assetPrefix will be unused)"; \
+      pnpm run build; \
+    fi
 
-# Strip TURBO_TOKEN from the env so it doesn't leak into the runner stage's
+# Strip secrets from the env so they don't leak into the runner stage's
 # inherited env or any subsequent layers. (The runner stage starts FROM a
 # fresh base image anyway, but be defensive.)
-ENV TURBO_TOKEN=""
+ENV TURBO_TOKEN="" \
+    R2_SECRET_ACCESS_KEY="" \
+    R2_ACCESS_KEY_ID=""
 
 
 # ── Stage 3: Production runner ───────────────────────────────────────────

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -27,10 +27,27 @@
 			// Configure these in the Cloudflare dashboard:
 			//   Workers & Pages → primalprinting → Settings → Builds →
 			//   Variables and Secrets
-			// (mark TURBO_TOKEN as "Secret")
+			// (mark TURBO_TOKEN, R2_SECRET_ACCESS_KEY as "Secret")
+			//
+			// R2_* vars feed the build-time `pnpm upload-assets` step that
+			// mirrors .next/static + public/ to the assets bucket so Next's
+			// `assetPrefix` can serve them from the CDN. They reuse the
+			// same R2 credentials already configured for runtime media
+			// access — only the bucket differs (R2_ASSETS_BUCKET).
+			//
+			// NEXT_PUBLIC_ASSET_PREFIX is baked into the client bundle at
+			// build time (Next inlines NEXT_PUBLIC_* vars). The runtime
+			// value is also injected via the worker env passthrough in
+			// container-worker.js so the entrypoint placeholder swap can
+			// re-target a different CDN per deploy if needed.
 			"image_vars": {
 				"TURBO_TEAM": "${TURBO_TEAM}",
-				"TURBO_TOKEN": "${TURBO_TOKEN}"
+				"TURBO_TOKEN": "${TURBO_TOKEN}",
+				"NEXT_PUBLIC_ASSET_PREFIX": "${NEXT_PUBLIC_ASSET_PREFIX}",
+				"R2_ASSETS_BUCKET": "${R2_ASSETS_BUCKET}",
+				"R2_S3_ENDPOINT": "${R2_S3_ENDPOINT}",
+				"R2_ACCESS_KEY_ID": "${R2_ACCESS_KEY_ID}",
+				"R2_SECRET_ACCESS_KEY": "${R2_SECRET_ACCESS_KEY}"
 			}
 		}
 	],


### PR DESCRIPTION
## Why

The R2 `assets` bucket and the `scripts/upload-assets.mts` mirror script have been in the codebase since #55, but **nothing has actually been invoking them** — the Cloudflare deploy still runs plain `pnpm run build` (i.e. just `next build`).

That meant: if you ever set `NEXT_PUBLIC_ASSET_PREFIX` in the worker runtime env, Next would point at a CDN URL that has zero objects in it → 404s for every static asset → site is broken. Hence the user's question "is upload-assets even being run currently?" — answer: no, not yet. This PR fixes that.

## What changes

### `wrangler.jsonc`

Threads the build-time inputs the upload script needs through `image_vars`:

```jsonc
"image_vars": {
  "TURBO_TEAM":               "${TURBO_TEAM}",
  "TURBO_TOKEN":              "${TURBO_TOKEN}",
  "NEXT_PUBLIC_ASSET_PREFIX": "${NEXT_PUBLIC_ASSET_PREFIX}",
  "R2_ASSETS_BUCKET":         "${R2_ASSETS_BUCKET}",
  "R2_S3_ENDPOINT":           "${R2_S3_ENDPOINT}",
  "R2_ACCESS_KEY_ID":         "${R2_ACCESS_KEY_ID}",
  "R2_SECRET_ACCESS_KEY":     "${R2_SECRET_ACCESS_KEY}"
}
```

These all source from the existing Cloudflare Workers Build env vars, so no new credentials need provisioning. `R2_SECRET_ACCESS_KEY` should be marked **Secret** in the dashboard.

### `Dockerfile`

- New `ARG` blocks for the R2 credentials, re-exported as `ENV` so they're visible to the upload script.
- `NEXT_PUBLIC_ASSET_PREFIX` converted from plain `ENV` to `ARG` + `ENV` so the real value (not just the `__NEXT_PUBLIC_ASSET_PREFIX__` placeholder) is baked into the build. The runtime placeholder swap in `docker-entrypoint.sh` continues to work as before, so the same image can still target a different CDN per deploy if needed.
- Build step now switches between `pnpm run build:headless` and `pnpm run build` based on whether R2 credentials are present:
  ```bash
  if [ -n "$R2_ASSETS_BUCKET" ] && [ -n "$R2_ACCESS_KEY_ID" ] && [ -n "$R2_SECRET_ACCESS_KEY" ] && [ -n "$R2_S3_ENDPOINT" ]; then
    pnpm run build:headless
  else
    pnpm run build
  fi
  ```
  → Cloudflare deploys (with creds) get the upload, local `docker build` (without creds) still works.
- Extended the literal-placeholder-stripper loop from #57 to cover the new vars too.
- Strip `R2_SECRET_ACCESS_KEY` / `R2_ACCESS_KEY_ID` at the end of the builder stage so they don't leak into subsequent layers (the runner stage is fresh anyway, but defensive).

## Caching

The upload step is a Turbo task with proper input fences, so on a tree-unchanged re-deploy it's a near-instant no-op. Even on a real change, the upload script HEAD-skips fingerprinted files in `_next/static/` that already exist in R2.

## Verification after merge

In the Cloudflare deploy log you should see:

```
→ Building with headless asset upload (R2_ASSETS_BUCKET=primalprinting-assets)
…
▶ Uploading static assets to R2 bucket "primalprinting-assets"…
✓ Asset sync complete in N.Ns — X uploaded, Y skipped, 0 failed
```

Then once `NEXT_PUBLIC_ASSET_PREFIX` is set in the runtime worker env (it's already in `container-worker.js`'s passthrough list), Next will start serving static assets from the R2 URL.