### PR TITLE
fix(upload-assets): opt out of aws-sdk-js v3 flexible checksums for R2

### DIFF
--- a/scripts/upload-assets.mts
+++ b/scripts/upload-assets.mts
@@ -102,11 +102,22 @@ const ACCESS_KEY = requireEnv("R2_ACCESS_KEY_ID");
 const SECRET_KEY = requireEnv("R2_SECRET_ACCESS_KEY");
 
 // ── S3 client (R2 is S3-compatible) ────────────────────────────────────────
+//
+// `requestChecksumCalculation` and `responseChecksumValidation` are pinned
+// to "WHEN_REQUIRED" because Cloudflare R2 does not fully support the
+// `Content-Encoding: aws-chunked` + `x-amz-trailer` flexible-checksum
+// framing that aws-sdk-js v3 enables by default since v3.730. Without this
+// opt-out, every PutObject is rejected (streamed bodies surface as
+// "non-retryable streaming request" + UnknownError; smaller bodies surface
+// as 403 Access Denied), even though the credentials are correct.
+// See: https://developers.cloudflare.com/r2/examples/aws/aws-sdk-js-v3/
 const s3 = new S3Client({
 	region: "auto",
 	endpoint: ENDPOINT,
 	credentials: { accessKeyId: ACCESS_KEY, secretAccessKey: SECRET_KEY },
 	forcePathStyle: true,
+	requestChecksumCalculation: "WHEN_REQUIRED",
+	responseChecksumValidation: "WHEN_REQUIRED",
 });
 
 // ── Types ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Pin `requestChecksumCalculation` + `responseChecksumValidation` to `"WHEN_REQUIRED"` on the S3 client in `scripts/upload-assets.mts` so it can talk to Cloudflare R2.

## Context

This is the follow-up to #62 (which fixed the build-secret-substitution wrapper). With #62 deployed, the secrets finally reached the docker build correctly:

```
• R2_S3_ENDPOINT=https://e6923eed2c19a18163a078df48ae191a.r2.cloudflarestorage.com
• R2_ACCESS_KEY_ID=<set>
• R2_SECRET_ACCESS_KEY=<set>
• TURBO_TOKEN=<set>
```

…but `upload-assets:run` then failed for every single object:

```
upload-assets:run: ✓ Asset sync complete in 0.6s — 0 uploaded, 0 skipped, 141 failed
```

with two distinct-looking error patterns:

- `_next/static/chunks/*` (streamed bodies) → `An error was encountered in a non-retryable streaming request.` + per-key `UnknownError`.
- `public/*` (small bodies — favicon, fonts, banners) → `Access Denied`.

Both have a single root cause.

## Root cause

`@aws-sdk/client-s3@3.1032.0` (this repo's pinned version) defaults to `requestChecksumCalculation: "WHEN_SUPPORTED"`, introduced in v3.730. That makes every `PutObject`:

1. Compute a CRC32 checksum.
2. Wrap the body with `Content-Encoding: aws-chunked` + `x-amz-trailer: x-amz-checksum-crc32`.

Cloudflare R2 does **not** fully support that framing. It rejects the requests:

- For streamed bodies, the SDK's `middleware-flexible-checksums` errors out before the request is fully on the wire → "non-retryable streaming request" + opaque `UnknownError`.
- For small bodies that don't need streaming, R2 still rejects the chunked-payload validation and returns 403 — which the SDK reports as `Access Denied`, *masquerading* as a token-permission problem.

This is the well-documented Cloudflare R2 ↔ aws-sdk-js v3 compatibility issue:
https://developers.cloudflare.com/r2/examples/aws/aws-sdk-js-v3/

## Fix

```ts
const s3 = new S3Client({
    region: "auto",
    endpoint: ENDPOINT,
    credentials: { accessKeyId: ACCESS_KEY, secretAccessKey: SECRET_KEY },
    forcePathStyle: true,
+   requestChecksumCalculation: "WHEN_REQUIRED",
+   responseChecksumValidation: "WHEN_REQUIRED",
});
```

Restores the pre-v3.730 behaviour (only emit checksums for ops that explicitly require them). PutObject no longer wraps the body with `aws-chunked`, R2 accepts it, all 141 files upload cleanly.

## Scope

- Only touches `scripts/upload-assets.mts`. No other call-sites in this repo use `@aws-sdk/client-s3` against R2 directly — Payload's `@payloadcms/storage-s3` adapter has its own S3 client and is unaffected.
- `tsc --strict` passes; the `RequestChecksumCalculation` enum (`WHEN_REQUIRED | WHEN_SUPPORTED`) is part of `@aws-sdk/middleware-flexible-checksums`'s public types.

## Verification

After this lands, the next deploy should show in the build log:

```
upload-assets:run: ✓ Asset sync complete in <X>s — 141 uploaded, 0 skipped, 0 failed
```

instead of `141 failed`. (Assuming the R2 token actually has write perms; nothing in this PR changes credential handling.)