### PR TITLE
perf(turbo): make build:next cache portable and stop caching upload-assets

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -20,9 +20,7 @@
 				"NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY",
 				"NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT",
 				"NEXT_PUBLIC_DISCOUNT_PERCENT",
-				"NEXT_PUBLIC_ASSET_PREFIX",
-				"DATABASE_URI",
-				"PAYLOAD_SECRET"
+				"NEXT_PUBLIC_ASSET_PREFIX"
 			],
 			"inputs": [
 				"$TURBO_DEFAULT$",
@@ -35,13 +33,7 @@
 		},
 		"upload-assets:run": {
 			"dependsOn": ["build:next"],
-			"env": [
-				"NEXT_PUBLIC_ASSET_PREFIX",
-				"R2_ASSETS_BUCKET",
-				"R2_S3_ENDPOINT",
-				"R2_ACCESS_KEY_ID",
-				"R2_SECRET_ACCESS_KEY"
-			],
+			"cache": false,
 			"inputs": ["scripts/upload-assets.mts", ".next/static/**", "public/**"],
 			"outputs": [".next/asset-upload.manifest.json"]
 		},


### PR DESCRIPTION
## Why every CI deploy is a cache miss

Two distinct issues, both in `turbo.json`:

### Issue A — `build:next`'s cache key includes runtime-only env vars

`turbo.json` listed these in `build:next`'s `env`:

```
NEXT_PUBLIC_BASE_URL
NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT
NEXT_PUBLIC_DISCOUNT_PERCENT
NEXT_PUBLIC_ASSET_PREFIX
DATABASE_URI       ← runtime-only
PAYLOAD_SECRET     ← runtime-only
```

Turbo factors **the values** of `env` entries into the cache key. So if `DATABASE_URI` is `mongodb://localhost/dev` locally, `mongodb+srv://prod-cluster/...` in CI, and a different value in prod docker, **no two environments will ever share a cache entry** — even when source bytes are identical. Every deploy is a guaranteed miss.

Both vars are runtime-only — Next never reads them at build time:

- `DATABASE_URI` → read by Payload + the Mongo adapter at request time, not during `next build`.
- `PAYLOAD_SECRET` → used to sign session JWTs at runtime; doesn't affect any built bytes.

The 5 `NEXT_PUBLIC_*` vars stay because Next inlines them into the client bundle at build time → they genuinely affect output and must invalidate the cache.

### Issue B — `upload-assets:run` will always miss by design

```json
"inputs": ["scripts/upload-assets.mts", ".next/static/**", "public/**"]
```

`.next/static/**` is the **output** of `build:next`. Next stamps a fresh `BUILD_ID` into `_buildManifest.js` on every build, and Turbopack chunk hashes shift between builds even on identical source. So `upload-assets:run`'s input hash changes every build → guaranteed miss every time, regardless of whether `build:next` was a hit or miss.

Also: caching a side-effect against a live external system (R2) is fragile (bucket wiped, manifest stale, `objectExists` logic changes, token rotated). The script's own per-file `objectExists()` HEAD probes already implement "skip already-uploaded immutable files" semantics — that's a better, more honest skip mechanism than Turbo's whole-task cache.

## Changes

1. **`build:next`** → drop `DATABASE_URI` + `PAYLOAD_SECRET` from `env`.
2. **`upload-assets:run`** → set `"cache": false`. Drop the now-irrelevant `env` block.

## Verified locally

```
default env                                  → hash A
DATABASE_URI=different-value                 → hash A   ✅ same
PAYLOAD_SECRET=different-value               → hash A   ✅ same
NEXT_PUBLIC_BASE_URL=different-value         → hash B   ✅ different
```

## Expected impact

- **First deploy after merge**: full cache miss (the hash changed because the cache key dropped two env vars → new entry written).
- **Second+ deploys with no source change**: `build:next` cache hit, `upload-assets:run` runs unconditionally but uploads only what's missing via the per-file HEAD probes that already exist.
- Build-time savings of roughly 60 seconds per deploy when source hasn't changed.