### PR TITLE
fix(turbo): pass R2 credentials through to upload-assets:run

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -34,6 +34,13 @@
 		"upload-assets:run": {
 			"dependsOn": ["build:next"],
 			"cache": false,
+			"env": [
+				"R2_ASSETS_BUCKET",
+				"R2_S3_ENDPOINT",
+				"R2_ACCESS_KEY_ID",
+				"R2_SECRET_ACCESS_KEY",
+				"NEXT_PUBLIC_ASSET_PREFIX"
+			],
 			"inputs": ["scripts/upload-assets.mts", ".next/static/**", "public/**"],
 			"outputs": [".next/asset-upload.manifest.json"]
 		},


### PR DESCRIPTION
## Summary

Cloudflare deploy was failing during the headless asset upload step:

```
upload-assets:run: ✗ Missing required env var: R2_ASSETS_BUCKET
```

…even though `R2_ASSETS_BUCKET` (and the other R2 credentials) are
correctly set in the build environment, validated by
`scripts/docker-build-step.sh` before it invokes `pnpm build:headless`.

## Root cause

Turbo 2 runs in **strict env mode** by default — only env vars declared
in a task's `env` block (or in `globalEnv` / `globalPassThroughEnv`)
are visible to the executed script. Everything else is stripped, even
if it's set in the parent shell.

The `upload-assets:run` task in `turbo.json` had **no `env` block**, so
when Turbo executed `scripts/upload-assets.mts` the four `R2_*` vars
were stripped from the environment and the script's `requireEnv()`
guard tripped immediately.

This regression was latent on `main` since the headless asset upload
feature landed (#58) — it only surfaced now because a recent change
to `build:next`'s cache key forced `upload-assets:run` to actually
execute (instead of being skipped via dependency cache from a prior
cached run that happened to inherit a working env).

## Fix

Declare the required env vars on `upload-assets:run`:

```diff
 "upload-assets:run": {
   "dependsOn": ["build:next"],
   "cache": false,
+  "env": [
+    "R2_ASSETS_BUCKET",
+    "R2_S3_ENDPOINT",
+    "R2_ACCESS_KEY_ID",
+    "R2_SECRET_ACCESS_KEY",
+    "NEXT_PUBLIC_ASSET_PREFIX"
+  ],
   "inputs": ["scripts/upload-assets.mts", ".next/static/**", "public/**"],
   "outputs": [".next/asset-upload.manifest.json"]
 },
```

The four `R2_*` vars exactly match the `requireEnv()` calls in
`scripts/upload-assets.mts`. `NEXT_PUBLIC_ASSET_PREFIX` is included
because the script also reads it for the published manifest URL.

`cache: false` is left as-is — the task should always re-run to
maintain idempotence with R2 (the script HEAD-skips already-uploaded
fingerprinted files, so re-runs on an unchanged tree are near-instant
no-ops).

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm turbo run upload-assets:run --dry-run` shows the new env
      vars in the cache key inputs
- [ ] Cloudflare deploy: confirm the build log shows
      `upload-assets:run` completing successfully (look for "✓ Asset
      upload manifest written") and not the `Missing required env var`
      error
