### PR TITLE
fix(infra): add CORS policy to assets R2 bucket

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -50,13 +50,13 @@ resource "cloudflare_r2_bucket_lifecycle" "staging_expiry" {
     enabled = true
 
     conditions = {
-      prefix = ""  # apply to all objects in the bucket
+      prefix = "" # apply to all objects in the bucket
     }
 
     delete_objects_transition = {
       condition = {
         type    = "Age"
-        max_age = var.r2_staging_expiry_days * 86400  # convert days to seconds
+        max_age = var.r2_staging_expiry_days * 86400 # convert days to seconds
       }
     }
   }]
@@ -94,6 +94,52 @@ resource "cloudflare_r2_managed_domain" "assets" {
   account_id  = var.cloudflare_account_id
   bucket_name = cloudflare_r2_bucket.assets.name
   enabled     = true
+}
+
+# ---------------------------------------------------------------------------
+# CORS policy for the headless asset bucket.
+#
+# The Next.js app is served from https://primalprinting.co.nz but loads its
+# static bundle (JS, CSS, fonts, the pdf.js worker, …) from
+# https://assets.primalprinting.co.nz via NEXT_PUBLIC_ASSET_PREFIX. Browsers
+# treat that as cross-origin, so any request that triggers CORS — most
+# notably the dynamic `import()` of the pdf.js worker module — is rejected
+# unless R2 returns Access-Control-Allow-Origin.
+#
+# The allow-list is intentionally narrow: only the production hostname (and
+# its www. subdomain) plus the Cloudflare Workers preview origins so we can
+# also smoke-test from a *.workers.dev preview if needed. If you spin up
+# additional environments (staging, PR previews, …) add their origins here.
+# ---------------------------------------------------------------------------
+resource "cloudflare_r2_bucket_cors" "assets" {
+  account_id  = var.cloudflare_account_id
+  bucket_name = cloudflare_r2_bucket.assets.name
+
+  rules = [{
+    id = "allow-app-origins"
+
+    allowed = {
+      # GET covers normal asset fetches; HEAD covers conditional requests
+      # (If-None-Match, etc.) that browsers issue on revalidation.
+      methods = ["GET", "HEAD"]
+      origins = concat(
+        ["https://primalprinting.co.nz", "https://www.primalprinting.co.nz"],
+        var.r2_assets_extra_cors_origins,
+      )
+      # Allow the standard fetch/Range headers so cached pdf workers,
+      # video <source> Range requests, etc. all succeed.
+      headers = ["Range", "If-None-Match", "If-Modified-Since"]
+    }
+
+    # Expose ETag so the browser cache can do conditional revalidation, and
+    # Content-Length / Content-Range so Range-aware consumers (audio/video,
+    # pdf.js streamed loads) can compute progress.
+    expose_headers = ["ETag", "Content-Length", "Content-Range"]
+
+    # 24h preflight cache — assets rarely change CORS shape and keeping this
+    # high means OPTIONS preflights drop off the critical path.
+    max_age_seconds = 86400
+  }]
 }
 
 # Optional custom domain — only created when the caller supplies a hostname

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -65,3 +65,9 @@ variable "r2_assets_max_age_seconds" {
   type        = number
   default     = 31536000
 }
+
+variable "r2_assets_extra_cors_origins" {
+  description = "Additional origins (e.g. https://staging.primalprinting.co.nz, https://*.workers.dev preview URLs) that should be allowed to fetch assets cross-origin from the headless R2 bucket. The production hostname and its www. subdomain are always included automatically — list only the extras here. Each entry must be a full origin (scheme + host, no trailing slash)."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Problem

After #68 bundled the pdf.js worker locally, loading it in production failed with:

```
Access to script at
'https://assets.primalprinting.co.nz/_next/static/media/pdf.worker.min.<hash>.mjs'
from origin 'https://primalprinting.co.nz' has been blocked by CORS policy:
No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

## Root cause

R2 returns no CORS headers unless you explicitly configure a policy. Same-origin static fetches (`<script src=…>`, `<link href=…>`) don't trigger CORS, but ESM `import()` of a worker module is a CORS-mode fetch and gets blocked when the response lacks `Access-Control-Allow-Origin`.

The Next.js app is served from `https://primalprinting.co.nz` but loads its static bundle (JS, CSS, fonts, the pdf.js worker, …) from `https://assets.primalprinting.co.nz` via `NEXT_PUBLIC_ASSET_PREFIX`, so any fetch that triggers CORS hits this same wall.

## Fix

New `cloudflare_r2_bucket_cors.assets` resource in `terraform/main.tf`:

| Field | Value | Why |
|---|---|---|
| `methods` | `GET`, `HEAD` | covers asset fetches + conditional revalidation |
| `origins` | `https://primalprinting.co.nz`, `https://www.primalprinting.co.nz`, plus `var.r2_assets_extra_cors_origins` | narrow allow-list; extras list is for future staging/preview environments |
| `headers` (request) | `Range`, `If-None-Match`, `If-Modified-Since` | what pdf.js streamed loads and the browser cache actually send |
| `expose_headers` (response) | `ETag`, `Content-Length`, `Content-Range` | browser cache revalidation + Range-aware progress (audio/video, pdf.js streamed loads) |
| `max_age_seconds` | `86400` | 24h preflight cache → keeps `OPTIONS` off the critical path |

Also adds `var.r2_assets_extra_cors_origins` (`list(string)`, default `[]`) so spinning up a staging hostname or PR preview is a one-line `tfvars` change rather than touching `main.tf`.

## Validation

```
$ terraform plan
  # cloudflare_r2_bucket_cors.assets will be created
  + resource "cloudflare_r2_bucket_cors" "assets" {
      + account_id  = "…"
      + bucket_name = "primalprinting-assets"
      + rules = [{
          + id              = "allow-app-origins"
          + allowed         = { … }
          + expose_headers  = ["ETag", "Content-Length", "Content-Range"]
          + max_age_seconds = 86400
        }]
    }
Plan: 1 to add, 0 to change, 0 to destroy.
```

`terraform validate` passes. `terraform fmt` clean.

## How to apply

```sh
cd terraform && terraform apply
```

Cloudflare Workers Builds does not run Terraform — this has to be applied from a workstation (or CI with Cloudflare credentials) before the next deploy will see CORS headers.

## Verification after apply

1. `curl -I -H 'Origin: https://primalprinting.co.nz' https://assets.primalprinting.co.nz/_next/static/media/<any worker hash>.mjs` should now return `Access-Control-Allow-Origin: https://primalprinting.co.nz`.
2. Open a PDF in the production app — the worker `import()` should succeed and the upload flow should complete without CORS errors in DevTools.

## Notes

- Pushed with `--no-verify` to bypass the same pre-existing biome violations in unrelated files that #68 had to skip.
