### PR TITLE
fix: bump NEXT_PUBLIC_DISCOUNT_PERCENT default 10 → 15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ ENV NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="__NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY__"
 # real values in at build time. Defaults match docker-entrypoint.sh /
 # container-worker.js so an unset build env still produces a working image.
 ARG NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT="2"
-ARG NEXT_PUBLIC_DISCOUNT_PERCENT="10"
+ARG NEXT_PUBLIC_DISCOUNT_PERCENT="15"
 ENV NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT=$NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT \
     NEXT_PUBLIC_DISCOUNT_PERCENT=$NEXT_PUBLIC_DISCOUNT_PERCENT
 # Asset prefix used by Next.js for /_next/static/* + /_next/image.

--- a/container-worker.js
+++ b/container-worker.js
@@ -54,7 +54,7 @@ export class PrimalPrinting extends Container {
 		// still useful for server-side code that reads them)
 		NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT:
 			env.NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT ?? "2",
-		NEXT_PUBLIC_DISCOUNT_PERCENT: env.NEXT_PUBLIC_DISCOUNT_PERCENT ?? "10",
+		NEXT_PUBLIC_DISCOUNT_PERCENT: env.NEXT_PUBLIC_DISCOUNT_PERCENT ?? "15",
 		// Headless asset hosting — points Next.js at the R2 assets bucket
 		// (or its custom domain) so the standalone server doesn't have to
 		// serve any static files. Empty string falls back to same-origin.

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -63,7 +63,7 @@
 				// from the headless asset CDN. Keep these in sync with the
 				// runtime defaults in container-worker.js / docker-entrypoint.sh.
 				"NEXT_PUBLIC_MINIMUM_ITEMS_FOR_DISCOUNT": "2",
-				"NEXT_PUBLIC_DISCOUNT_PERCENT": "10",
+				"NEXT_PUBLIC_DISCOUNT_PERCENT": "15",
 				// — Substituted from build-env Secrets at deploy time ——
 				"R2_S3_ENDPOINT": "${R2_S3_ENDPOINT}",
 				"R2_ACCESS_KEY_ID": "${R2_ACCESS_KEY_ID}",


### PR DESCRIPTION
## Summary

Bumps the bulk-discount percentage from **10% → 15%**, applied consistently across every touchpoint that defines the value or its fallback default.

## Why all three files

`NEXT_PUBLIC_DISCOUNT_PERCENT` is defined or defaulted in three independent places, and per `AGENTS.md` ("Environment Variable Sync") all defaults for the same env var must agree:

| File | Role | Change |
|---|---|---|
| `wrangler.jsonc` (`image_vars`) | **Canonical** build-time value passed into the container image | `"10"` → `"15"` |
| `Dockerfile` (`ARG NEXT_PUBLIC_DISCOUNT_PERCENT`) | Default baked into the image when no build arg is supplied | `"10"` → `"15"` |
| `container-worker.js` (`env.NEXT_PUBLIC_DISCOUNT_PERCENT ?? …`) | Runtime fallback the Container worker uses if Cloudflare doesn't pass the var through | `"10"` → `"15"` |

## Touchpoints intentionally left alone

- **`.env.local`** — gitignored, per-developer dev value
- **`docker-entrypoint.sh`** — only references the var in a comment, no default
- **`env.d.ts` / `scripts/docker-build-step.sh`** — declare / log the var but don't supply a default
- **`lib/utils.ts`** — uses `parseNumericEnv(..., 0)`; the `0` is the "absent" sentinel intentionally distinct from any production default (so a misconfigured deploy reads 0% rather than silently applying 15%)

## Validation

- All three changed files contain the new `"15"` (verified via `grep -rn DISCOUNT_PERCENT`).
- Pre-commit `biome check` passed.
- No code logic changed — purely a config value bump.

## Auto-merge

Enabled — will merge once required checks pass.
