### PR TITLE
fix: fetch contact info server-side to eliminate 403 on /api/globals/contact-info

### DIFF
--- a/components/footer/Footer.tsx
+++ b/components/footer/Footer.tsx
@@ -8,7 +8,6 @@ import {
 	UnorderedList,
 	useMediaQuery,
 } from "@chakra-ui/react";
-import { useEffect, useState } from "react";
 import SocialLinks from "../sociallinks/sociallinks";
 
 type ContactInfoData = {
@@ -17,36 +16,13 @@ type ContactInfoData = {
 };
 
 type Props = {
-	contactInfo?: ContactInfoData;
+	contactInfo: ContactInfoData;
 };
 
 export default function Footer({ contactInfo }: Props) {
 	const [smallScreen] = useMediaQuery("(max-width: 800px)");
-	const [fetchedContact, setFetchedContact] = useState<ContactInfoData | null>(
-		null,
-	);
-
-	// Fetch contact info from Payload if not passed as prop
-	useEffect(() => {
-		if (contactInfo?.email || contactInfo?.phone) return;
-
-		async function fetchContact() {
-			try {
-				const res = await fetch("/api/globals/contact-info");
-				if (res.ok) {
-					const data = await res.json();
-					setFetchedContact(data);
-				}
-			} catch {
-				// Silently fail
-			}
-		}
-		fetchContact();
-	}, [contactInfo]);
-
-	const contact = contactInfo?.email ? contactInfo : fetchedContact;
-	const email = contact?.email || "";
-	const phone = contact?.phone || "";
+	const email = contactInfo.email || "";
+	const phone = contactInfo.phone || "";
 
 	return (
 		<Box

--- a/components/ordercontainer/OrderContainer.tsx
+++ b/components/ordercontainer/OrderContainer.tsx
@@ -11,6 +11,7 @@ import {
 	useMediaQuery,
 } from "@chakra-ui/react";
 import { useRouter } from "next/router";
+import type { ReactNode } from "react";
 import { useCallback, useEffect, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { CartContextProvider } from "@/contexts/CartContext";
@@ -181,23 +182,20 @@ const OrderContainerInner = ({
 	// Show loading spinner while resuming an order
 	const isResuming = (resumeOrderId || pickupForOrderId) && !resumeChecked;
 
-	if (isResuming) {
-		return (
-			<>
-				<Box textAlign="center" py={16}>
-					<Spinner size="xl" color="brown.700" />
-					<Text mt={4} color="gray.500" fontSize="lg">
-						⏳ Resuming your order…
-					</Text>
-				</Box>
-				<Footer contactInfo={contactInfo} />
-			</>
-		);
-	}
+	let content: ReactNode;
 
-	// Show the step-based flow once we're past the upload stage
-	if (orderStep !== OrderStep.UPLOAD) {
-		return (
+	if (isResuming) {
+		content = (
+			<Box textAlign="center" py={16}>
+				<Spinner size="xl" color="brown.700" />
+				<Text mt={4} color="gray.500" fontSize="lg">
+					⏳ Resuming your order…
+				</Text>
+			</Box>
+		);
+	} else if (orderStep !== OrderStep.UPLOAD) {
+		// Show the step-based flow once we're past the upload stage
+		content = (
 			<>
 				<ProcessingOverlay show={isProcessing} items={currentlyUploading} />
 				<Box maxWidth="900px" margin="0 auto">
@@ -223,150 +221,162 @@ const OrderContainerInner = ({
 					onPaymentSuccess={handlePaymentSuccess}
 					onPickupConfirmed={handlePickupConfirmed}
 				/>
-				<Footer contactInfo={contactInfo} />
+			</>
+		);
+	} else {
+		content = (
+			<>
+				<ProcessingOverlay show={isProcessing} items={currentlyUploading} />
+				{pendingOrders.length > 0 && (
+					<Box
+						bg="blue.50"
+						border="1px solid"
+						borderColor="blue.200"
+						borderRadius="8px"
+						padding="0.75rem 1rem"
+						marginTop="1rem"
+						marginBottom="0.5rem"
+					>
+						<Text fontSize="sm" color="blue.800" mb={2} fontWeight={600}>
+							📋 You have {pendingOrders.length} in-progress order
+							{pendingOrders.length !== 1 ? "s" : ""}
+						</Text>
+						<Box display="flex" flexDir="column" gap={2}>
+							{pendingOrders.map((o) => (
+								<Box
+									key={o.id}
+									display="flex"
+									alignItems="center"
+									justifyContent="space-between"
+									bg="white"
+									borderRadius="6px"
+									padding="0.5rem 0.75rem"
+									flexWrap="wrap"
+									gap={2}
+								>
+									<Box display="flex" alignItems="center" gap={2} fontSize="sm">
+										<Text fontFamily="mono" fontWeight={600}>
+											{o.orderNumber}
+										</Text>
+										<Text color="gray.500">
+											{o.files?.length || 0} file
+											{(o.files?.length || 0) !== 1 ? "s" : ""} · $
+											{((o.pricing?.total || 0) / 100).toFixed(2)}
+										</Text>
+									</Box>
+									<Box display="flex" gap={1}>
+										<Button
+											size="xs"
+											colorScheme="blue"
+											onClick={() =>
+												router.push(
+													o.status === OrderStatus.PAID
+														? `/order?pickupFor=${o.id}`
+														: `/order?resume=${o.id}`,
+												)
+											}
+										>
+											{o.status === OrderStatus.PAID
+												? "Select Pickup"
+												: "Resume"}
+										</Button>
+										{o.status !== OrderStatus.PAID && (
+											<Button
+												size="xs"
+												colorScheme="red"
+												variant="ghost"
+												onClick={async () => {
+													if (
+														!window.confirm(
+															`Delete order ${o.orderNumber}? This cannot be undone.`,
+														)
+													)
+														return;
+													try {
+														const res = await fetch(
+															`/api/shop/${o.id}/delete`,
+															{
+																method: "DELETE",
+															},
+														);
+														if (!res.ok) {
+															const data = await res.json();
+															throw new Error(
+																data.error || "Failed to delete.",
+															);
+														}
+														setPendingOrders((prev) =>
+															prev.filter((p) => p.id !== o.id),
+														);
+													} catch (err) {
+														window.alert(
+															err instanceof Error
+																? err.message
+																: "Failed to delete order.",
+														);
+													}
+												}}
+											>
+												Delete
+											</Button>
+										)}
+									</Box>
+								</Box>
+							))}
+						</Box>
+					</Box>
+				)}
+				<ExtraInfo />
+				<Box
+					paddingTop="1rem"
+					display="grid"
+					columnGap="1rem"
+					rowGap="1rem"
+					gridTemplateColumns={smallScreen ? "1fr" : "3fr 1.5fr"}
+				>
+					<Box
+						border="1px"
+						borderColor="brown.200"
+						bg="white"
+						padding="1rem"
+						borderRadius="8px"
+						position="relative"
+						overflowX="visible"
+					>
+						<Box
+							position="absolute"
+							top="0"
+							left="-2rem"
+							h="100%"
+							w="2.8rem"
+							overflowY="hidden"
+							backgroundImage="/binder.png"
+						/>
+						<Tabs variant="enclosed" colorScheme="brown">
+							<TabList padding="0 1rem">
+								<Tab fontWeight="700">Upload PDF</Tab>
+							</TabList>
+							<TabPanels>
+								<TabPanel>
+									<PdfOrder />
+								</TabPanel>
+							</TabPanels>
+						</Tabs>
+					</Box>
+					<Cart
+						smallScreen={smallScreen}
+						onProceedToPayment={handleProceedToPayment}
+						setIsProcessing={setIsProcessing}
+						setCurrentlyUploading={setCurrentlyUploading}
+					/>
+				</Box>
 			</>
 		);
 	}
 
 	return (
 		<>
-			<ProcessingOverlay show={isProcessing} items={currentlyUploading} />
-			{pendingOrders.length > 0 && (
-				<Box
-					bg="blue.50"
-					border="1px solid"
-					borderColor="blue.200"
-					borderRadius="8px"
-					padding="0.75rem 1rem"
-					marginTop="1rem"
-					marginBottom="0.5rem"
-				>
-					<Text fontSize="sm" color="blue.800" mb={2} fontWeight={600}>
-						📋 You have {pendingOrders.length} in-progress order
-						{pendingOrders.length !== 1 ? "s" : ""}
-					</Text>
-					<Box display="flex" flexDir="column" gap={2}>
-						{pendingOrders.map((o) => (
-							<Box
-								key={o.id}
-								display="flex"
-								alignItems="center"
-								justifyContent="space-between"
-								bg="white"
-								borderRadius="6px"
-								padding="0.5rem 0.75rem"
-								flexWrap="wrap"
-								gap={2}
-							>
-								<Box display="flex" alignItems="center" gap={2} fontSize="sm">
-									<Text fontFamily="mono" fontWeight={600}>
-										{o.orderNumber}
-									</Text>
-									<Text color="gray.500">
-										{o.files?.length || 0} file
-										{(o.files?.length || 0) !== 1 ? "s" : ""} · $
-										{((o.pricing?.total || 0) / 100).toFixed(2)}
-									</Text>
-								</Box>
-								<Box display="flex" gap={1}>
-									<Button
-										size="xs"
-										colorScheme="blue"
-										onClick={() =>
-											router.push(
-												o.status === OrderStatus.PAID
-													? `/order?pickupFor=${o.id}`
-													: `/order?resume=${o.id}`,
-											)
-										}
-									>
-										{o.status === OrderStatus.PAID ? "Select Pickup" : "Resume"}
-									</Button>
-									{o.status !== OrderStatus.PAID && (
-										<Button
-											size="xs"
-											colorScheme="red"
-											variant="ghost"
-											onClick={async () => {
-												if (
-													!window.confirm(
-														`Delete order ${o.orderNumber}? This cannot be undone.`,
-													)
-												)
-													return;
-												try {
-													const res = await fetch(`/api/shop/${o.id}/delete`, {
-														method: "DELETE",
-													});
-													if (!res.ok) {
-														const data = await res.json();
-														throw new Error(data.error || "Failed to delete.");
-													}
-													setPendingOrders((prev) =>
-														prev.filter((p) => p.id !== o.id),
-													);
-												} catch (err) {
-													window.alert(
-														err instanceof Error
-															? err.message
-															: "Failed to delete order.",
-													);
-												}
-											}}
-										>
-											Delete
-										</Button>
-									)}
-								</Box>
-							</Box>
-						))}
-					</Box>
-				</Box>
-			)}
-			<ExtraInfo />
-			<Box
-				paddingTop="1rem"
-				display="grid"
-				columnGap="1rem"
-				rowGap="1rem"
-				gridTemplateColumns={smallScreen ? "1fr" : "3fr 1.5fr"}
-			>
-				<Box
-					border="1px"
-					borderColor="brown.200"
-					bg="white"
-					padding="1rem"
-					borderRadius="8px"
-					position="relative"
-					overflowX="visible"
-				>
-					<Box
-						position="absolute"
-						top="0"
-						left="-2rem"
-						h="100%"
-						w="2.8rem"
-						overflowY="hidden"
-						backgroundImage="/binder.png"
-					/>
-					<Tabs variant="enclosed" colorScheme="brown">
-						<TabList padding="0 1rem">
-							<Tab fontWeight="700">Upload PDF</Tab>
-						</TabList>
-						<TabPanels>
-							<TabPanel>
-								<PdfOrder />
-							</TabPanel>
-						</TabPanels>
-					</Tabs>
-				</Box>
-				<Cart
-					smallScreen={smallScreen}
-					onProceedToPayment={handleProceedToPayment}
-					setIsProcessing={setIsProcessing}
-					setCurrentlyUploading={setCurrentlyUploading}
-				/>
-			</Box>
+			{content}
 			<Footer contactInfo={contactInfo} />
 		</>
 	);

--- a/components/ordercontainer/OrderContainer.tsx
+++ b/components/ordercontainer/OrderContainer.tsx
@@ -23,15 +23,28 @@ import ExtraInfo from "./ExtraInfo";
 import OrderSteps from "./OrderSteps";
 import PdfOrder from "./PdfOrder";
 
-const OrderContainer = () => {
+type ContactInfoData = {
+	email: string;
+	phone: string;
+};
+
+type OrderContainerProps = {
+	contactInfo: ContactInfoData;
+};
+
+const OrderContainer = ({ contactInfo }: OrderContainerProps) => {
 	return (
 		<CartContextProvider>
-			<OrderContainerInner />
+			<OrderContainerInner contactInfo={contactInfo} />
 		</CartContextProvider>
 	);
 };
 
-const OrderContainerInner = () => {
+const OrderContainerInner = ({
+	contactInfo,
+}: {
+	contactInfo: ContactInfoData;
+}) => {
 	const [isProcessing, setIsProcessing] = useState(false);
 	const [currentlyUploading, setCurrentlyUploading] = useState<
 		{ name: string; percent: number }[]
@@ -177,7 +190,7 @@ const OrderContainerInner = () => {
 						⏳ Resuming your order…
 					</Text>
 				</Box>
-				<Footer />
+				<Footer contactInfo={contactInfo} />
 			</>
 		);
 	}
@@ -210,7 +223,7 @@ const OrderContainerInner = () => {
 					onPaymentSuccess={handlePaymentSuccess}
 					onPickupConfirmed={handlePickupConfirmed}
 				/>
-				<Footer />
+				<Footer contactInfo={contactInfo} />
 			</>
 		);
 	}
@@ -354,7 +367,7 @@ const OrderContainerInner = () => {
 					setCurrentlyUploading={setCurrentlyUploading}
 				/>
 			</Box>
-			<Footer />
+			<Footer contactInfo={contactInfo} />
 		</>
 	);
 };

--- a/pages/my-orders.tsx
+++ b/pages/my-orders.tsx
@@ -11,6 +11,7 @@ import type { NextPage } from "next";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useState } from "react";
+import { getPayloadClient } from "@/lib/payload";
 import Footer from "../components/footer/Footer";
 import NavBar from "../components/navbar/NavBar";
 import { useAuth } from "../contexts/AuthContext";
@@ -19,6 +20,33 @@ import {
 	type OrderStatusValue,
 	RESUMABLE_STATUSES,
 } from "../types/orderStatus";
+
+type ContactInfoData = {
+	email: string;
+	phone: string;
+};
+
+type PageProps = {
+	contactInfo: ContactInfoData;
+};
+
+export async function getServerSideProps() {
+	try {
+		const payload = await getPayloadClient();
+		const contactInfo = await payload.findGlobal({ slug: "contact-info" });
+		return {
+			props: {
+				contactInfo: JSON.parse(JSON.stringify(contactInfo)),
+			},
+		};
+	} catch {
+		return {
+			props: {
+				contactInfo: { email: "", phone: "" },
+			},
+		};
+	}
+}
 
 interface Order {
 	id: string;
@@ -67,7 +95,7 @@ const containerProps = {
 	borderRadius: "8px",
 };
 
-const MyOrders: NextPage = () => {
+const MyOrders: NextPage<PageProps> = ({ contactInfo }) => {
 	const { isAuthenticated, isLoading: authLoading, login, name } = useAuth();
 	const router = useRouter();
 	const [orders, setOrders] = useState<Order[]>([]);
@@ -113,7 +141,7 @@ const MyOrders: NextPage = () => {
 							Sign in with Google
 						</Button>
 					</Box>
-					<Footer />
+					<Footer contactInfo={contactInfo} />
 				</Box>
 			</>
 		);
@@ -286,7 +314,7 @@ const MyOrders: NextPage = () => {
 						</Box>
 					)}
 				</Box>
-				<Footer />
+				<Footer contactInfo={contactInfo} />
 			</Box>
 		</>
 	);

--- a/pages/order.tsx
+++ b/pages/order.tsx
@@ -1,17 +1,38 @@
 import { Box } from "@chakra-ui/react";
 import type { NextPage } from "next";
 import Head from "next/head";
+import { getPayloadClient } from "@/lib/payload";
 import NavBar from "../components/navbar/NavBar";
 import OrderContainer from "../components/ordercontainer/OrderContainer";
-export async function getStaticProps() {
-	return {
-		props: {
-			packages: [], // packages,
-		},
-		revalidate: 60 * 60,
-	};
+
+type ContactInfoData = {
+	email: string;
+	phone: string;
+};
+
+type PageProps = {
+	contactInfo: ContactInfoData;
+};
+
+export async function getServerSideProps() {
+	try {
+		const payload = await getPayloadClient();
+		const contactInfo = await payload.findGlobal({ slug: "contact-info" });
+		return {
+			props: {
+				contactInfo: JSON.parse(JSON.stringify(contactInfo)),
+			},
+		};
+	} catch {
+		return {
+			props: {
+				contactInfo: { email: "", phone: "" },
+			},
+		};
+	}
 }
-const Order: NextPage = () => {
+
+const Order: NextPage<PageProps> = ({ contactInfo }) => {
 	return (
 		<>
 			<Head>
@@ -30,7 +51,7 @@ const Order: NextPage = () => {
 			</Head>
 			<Box className="container">
 				<NavBar />
-				<OrderContainer />
+				<OrderContainer contactInfo={contactInfo} />
 			</Box>
 		</>
 	);

--- a/pages/order_complete.tsx
+++ b/pages/order_complete.tsx
@@ -2,9 +2,37 @@ import { Box, Button, Divider, Heading, Spinner, Text } from "@chakra-ui/react";
 import type { NextPage } from "next";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
+import { getPayloadClient } from "@/lib/payload";
 import Footer from "../components/footer/Footer";
 import NoSsr from "../components/NoSsr";
 import NavBar from "../components/navbar/NavBar";
+
+type ContactInfoData = {
+	email: string;
+	phone: string;
+};
+
+type PageProps = {
+	contactInfo: ContactInfoData;
+};
+
+export async function getServerSideProps() {
+	try {
+		const payload = await getPayloadClient();
+		const contactInfo = await payload.findGlobal({ slug: "contact-info" });
+		return {
+			props: {
+				contactInfo: JSON.parse(JSON.stringify(contactInfo)),
+			},
+		};
+	} catch {
+		return {
+			props: {
+				contactInfo: { email: "", phone: "" },
+			},
+		};
+	}
+}
 
 interface OrderDetails {
 	orderNumber: string;
@@ -32,7 +60,7 @@ interface OrderDetails {
  *
  * Fetches the order from the API and shows a confirmation summary.
  */
-const OrderComplete: NextPage = () => {
+const OrderComplete: NextPage<PageProps> = ({ contactInfo }) => {
 	const router = useRouter();
 	const orderId = router.query.orderId as string | undefined;
 	const [order, setOrder] = useState<OrderDetails | null>(null);
@@ -218,7 +246,7 @@ const OrderComplete: NextPage = () => {
 						</>
 					)}
 				</Box>
-				<Footer />
+				<Footer contactInfo={contactInfo} />
 			</Box>
 		</NoSsr>
 	);


### PR DESCRIPTION
## Problem

The Footer component was falling back to a client-side `fetch("/api/globals/contact-info")` when `contactInfo` wasn't passed as a prop. This returned **403** because the Payload CMS global requires authentication by default.

This affected every page where `<Footer />` was rendered without the prop:
- `pages/order.tsx` (via `OrderContainer` — 3 instances)
- `pages/my-orders.tsx` (2 instances)
- `pages/order_complete.tsx` (1 instance)

## Solution

Moved contact info fetching entirely to server-side rendering (`getServerSideProps`) and removed the client-side fetch from the Footer component.

### Changes

- **`components/footer/Footer.tsx`** — Removed `useEffect`/`useState` client-side fetch; made `contactInfo` a required prop
- **`pages/order.tsx`** — Replaced `getStaticProps` with `getServerSideProps` that fetches `contactInfo` via Payload local API; passes it to `OrderContainer`
- **`components/ordercontainer/OrderContainer.tsx`** — Accepts `contactInfo` prop and forwards it to all 3 `<Footer>` renders
- **`pages/my-orders.tsx`** — Added `getServerSideProps` to fetch `contactInfo`; passes to both `<Footer>` renders
- **`pages/order_complete.tsx`** — Added `getServerSideProps` to fetch `contactInfo`; passes to `<Footer>`

### Result

- No more 403 errors on `/api/globals/contact-info`
- Contact info is always fresh (fetched on every request, server-side)
- No client-side API calls for contact info
- Consistent with how `index.tsx` and `contact.tsx` already handle it