### PR TITLE
fix(ci): resolve 'Unrecognized named-value: matrix' in cron workflow

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -71,10 +71,10 @@ jobs:
     #     was given or the filter matches this matrix entry, OR
     #   • the schedule cron expression matches this entry's schedule.
     if: >-
-      github.event_name == 'workflow_dispatch'
+      ${{ github.event_name == 'workflow_dispatch'
         && (github.event.inputs.endpoint == 'all' || github.event.inputs.endpoint == matrix.endpoint)
       || github.event_name == 'schedule'
-        && github.event.schedule == matrix.schedule
+        && github.event.schedule == matrix.schedule }}
 
     steps:
       - name: Call ${{ matrix.endpoint }}


### PR DESCRIPTION
## Problem

The cron workflow (`.github/workflows/cron.yml`) fails validation with:

```
(Line: 73, Col: 9): Unrecognized named-value: 'matrix'. Located at position 121 within expression: ...
```

GitHub Actions does not recognize bare `matrix.*` references in job-level `if:` conditions. The `matrix` context is only auto-available inside `${{ }}` expression blocks at the job level.

## Fix

Wrap the entire job-level `if:` expression in `${{ ... }}` so that `matrix.endpoint` and `matrix.schedule` are properly resolved.

## Changes

- `.github/workflows/cron.yml`: Added `${{ }}` wrapper around the `if:` condition on the `run` job.