### PR TITLE
fix(ci): move matrix filter from job-level if to step-level if

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -66,18 +66,17 @@ jobs:
 
     name: ${{ matrix.name }}
 
-    # Run when:
-    #   • manually dispatched (workflow_dispatch) AND either no endpoint filter
-    #     was given or the filter matches this matrix entry, OR
-    #   • the schedule cron expression matches this entry's schedule.
-    if: >-
-      ${{ github.event_name == 'workflow_dispatch'
-        && (github.event.inputs.endpoint == 'all' || github.event.inputs.endpoint == matrix.endpoint)
-      || github.event_name == 'schedule'
-        && github.event.schedule == matrix.schedule }}
-
     steps:
+      # Run when:
+      #   • manually dispatched (workflow_dispatch) AND either no endpoint filter
+      #     was given or the filter matches this matrix entry, OR
+      #   • the schedule cron expression matches this entry's schedule.
       - name: Call ${{ matrix.endpoint }}
+        if: >-
+          github.event_name == 'workflow_dispatch'
+            && (github.event.inputs.endpoint == 'all' || github.event.inputs.endpoint == matrix.endpoint)
+          || github.event_name == 'schedule'
+            && github.event.schedule == matrix.schedule
         env:
           DEPLOY_URL: ${{ vars.DEPLOY_URL }}
           CRON_SECRET: ${{ secrets.CRON_SECRET }}


### PR DESCRIPTION
## Problem

The cron workflow (`.github/workflows/cron.yml`) fails validation with:

```
(Line: 73, Col: 9): Unrecognized named-value: 'matrix'.
```

The `matrix` context is **not available** in job-level `if:` conditions — GitHub Actions evaluates those before expanding the matrix, so `matrix.endpoint` and `matrix.schedule` are unrecognized.

## Fix

Move the `if:` condition from the **job level** to the **step level**, where the `matrix` context is properly available.

## Changes

- `.github/workflows/cron.yml`: Removed the job-level `if:` and added an equivalent step-level `if:` on the curl step.