### PR TITLE
feat: include file details in all email templates

### DIFF
--- a/app/api/admin/notify-timeslots/route.ts
+++ b/app/api/admin/notify-timeslots/route.ts
@@ -75,7 +75,10 @@ export async function POST(request: NextRequest) {
 			{
 				email: string;
 				name: string;
-				orders: { orderNumber: string }[];
+				orders: {
+					orderNumber: string;
+					files: NonNullable<(typeof orders.docs)[number]["files"]>;
+				}[];
 			}
 		>();
 
@@ -88,12 +91,18 @@ export async function POST(request: NextRequest) {
 			if (existing) {
 				existing.orders.push({
 					orderNumber: order.orderNumber || order.id,
+					files: order.files || [],
 				});
 			} else {
 				customerMap.set(customer.email, {
 					email: customer.email,
 					name: customer.name || "Customer",
-					orders: [{ orderNumber: order.orderNumber || order.id }],
+					orders: [
+						{
+							orderNumber: order.orderNumber || order.id,
+							files: order.files || [],
+						},
+					],
 				});
 			}
 		}

--- a/app/api/shop/[orderId]/resend-confirmation/route.ts
+++ b/app/api/shop/[orderId]/resend-confirmation/route.ts
@@ -99,7 +99,8 @@ export async function POST(request: NextRequest, context: RouteContext) {
 				to: customer.email,
 				customerName,
 				orderNumber,
-				total: order.pricing?.total,
+				files: order.files || [],
+				pricing: order.pricing,
 				hasTimeslots,
 			});
 

--- a/app/api/shop/[orderId]/submit-bank-transfer/route.ts
+++ b/app/api/shop/[orderId]/submit-bank-transfer/route.ts
@@ -148,7 +148,8 @@ export async function POST(request: NextRequest, context: RouteContext) {
 				to: customer.email,
 				customerName: customer.name,
 				orderNumber: updated.orderNumber || "",
-				total: order.pricing?.total,
+				files: order.files || [],
+				pricing: order.pricing,
 				hasTimeslots,
 			});
 		} catch (emailError) {

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.1.1/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",
@@ -32,7 +32,19 @@
 		}
 	},
 	"files": {
-		"includes": ["**", "!**/importMap.js"],
+		"includes": [
+			"**",
+			"!**/importMap.js",
+			"!**/node_modules",
+			"!**/.next",
+			"!**/.turbo",
+			"!**/.wrangler",
+			"!**/out",
+			"!**/build",
+			"!**/coverage",
+			"!**/terraform/.terraform",
+			"!**/pnpm-lock.yaml"
+		],
 		"ignoreUnknown": true
 	}
 }

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -227,9 +227,7 @@ function formatCents(cents: number | undefined | null): string {
 }
 
 /** Map raw OrderFile[] into template-friendly objects with display labels. */
-function formatFilesForTemplate(
-	files: OrderFile[],
-): Record<string, unknown>[] {
+function formatFilesForTemplate(files: OrderFile[]): Record<string, unknown>[] {
 	return files.map((f) => ({
 		...f,
 		colorLabel: f.colorMode === "COLOR" ? "Colour" : "B&W",

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -136,10 +136,12 @@ export async function sendBankTransferReceivedEmail(params: {
 	to: string;
 	customerName: string;
 	orderNumber: string;
-	total: number | undefined;
+	files: OrderFile[];
+	pricing: PricingInfo | undefined;
 	hasTimeslots: boolean;
 }): Promise<void> {
-	const { to, customerName, orderNumber, total, hasTimeslots } = params;
+	const { to, customerName, orderNumber, files, pricing, hasTimeslots } =
+		params;
 
 	const contact = await getContactInfo();
 	const ordersUrl = `${process.env.NEXT_PUBLIC_BASE_URL || ""}/my-orders`;
@@ -147,7 +149,14 @@ export async function sendBankTransferReceivedEmail(params: {
 	const html = renderTemplate("paymentPendingVerification", {
 		customerName: customerName || "Customer",
 		orderNumber,
-		total: formatCents(total),
+		files: files.map((f) => ({
+			...f,
+			colorLabel: f.colorMode === "COLOR" ? "Colour" : "B&W",
+			sidedLabel: f.doubleSided ? "Double-sided" : "Single-sided",
+		})),
+		subtotal: formatCents(pricing?.subtotal),
+		tax: formatCents(pricing?.tax),
+		total: formatCents(pricing?.total),
 		hasTimeslots,
 		ordersUrl,
 		contactEmail: contact.email,
@@ -216,7 +225,7 @@ export async function sendPaymentConfirmationEmail(params: {
 export async function sendTimeslotsAvailableEmail(params: {
 	to: string;
 	customerName: string;
-	orders: { orderNumber: string }[];
+	orders: { orderNumber: string; files: OrderFile[] }[];
 }): Promise<void> {
 	const { to, customerName, orders } = params;
 
@@ -225,7 +234,14 @@ export async function sendTimeslotsAvailableEmail(params: {
 
 	const html = renderTemplate("timeslotsAvailable", {
 		customerName: customerName || "Customer",
-		orders,
+		orders: orders.map((o) => ({
+			...o,
+			files: o.files.map((f) => ({
+				...f,
+				colorLabel: f.colorMode === "COLOR" ? "Colour" : "B&W",
+				sidedLabel: f.doubleSided ? "Double-sided" : "Single-sided",
+			})),
+		})),
 		ordersUrl,
 		contactEmail: contact.email,
 		contactPhone: contact.phone,

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -100,28 +100,20 @@ export async function sendOrderConfirmationEmail(params: {
 			})
 		: "TBD";
 
-	const contact = await getContactInfo();
+	const common = await buildCommonLocals(customerName);
 
 	const html = renderTemplate("orderConfirmation", {
-		customerName: customerName || "Customer",
+		...common,
 		orderNumber,
-		files: files.map((f) => ({
-			...f,
-			colorLabel: f.colorMode === "COLOR" ? "Colour" : "B&W",
-			sidedLabel: f.doubleSided ? "Double-sided" : "Single-sided",
-		})),
-		subtotal: formatCents(pricing?.subtotal),
-		tax: formatCents(pricing?.tax),
-		total: formatCents(pricing?.total),
+		files: formatFilesForTemplate(files),
+		...formatPricingForTemplate(pricing),
 		pickupDate: formattedDate,
 		pickupTime: `${timeslot.startTime} – ${timeslot.endTime}`,
 		pickupLabel: timeslot.label,
-		contactEmail: contact.email,
-		contactPhone: contact.phone,
 	});
 
 	await getTransporter().sendMail({
-		from: `"Primal Printing" <${process.env.GMAIL_USER}>`,
+		from: fromAddress(),
 		to,
 		subject: `Order Confirmed — ${orderNumber}`,
 		html,
@@ -143,28 +135,18 @@ export async function sendBankTransferReceivedEmail(params: {
 	const { to, customerName, orderNumber, files, pricing, hasTimeslots } =
 		params;
 
-	const contact = await getContactInfo();
-	const ordersUrl = `${process.env.NEXT_PUBLIC_BASE_URL || ""}/my-orders`;
+	const common = await buildCommonLocals(customerName);
 
 	const html = renderTemplate("paymentPendingVerification", {
-		customerName: customerName || "Customer",
+		...common,
 		orderNumber,
-		files: files.map((f) => ({
-			...f,
-			colorLabel: f.colorMode === "COLOR" ? "Colour" : "B&W",
-			sidedLabel: f.doubleSided ? "Double-sided" : "Single-sided",
-		})),
-		subtotal: formatCents(pricing?.subtotal),
-		tax: formatCents(pricing?.tax),
-		total: formatCents(pricing?.total),
+		files: formatFilesForTemplate(files),
+		...formatPricingForTemplate(pricing),
 		hasTimeslots,
-		ordersUrl,
-		contactEmail: contact.email,
-		contactPhone: contact.phone,
 	});
 
 	await getTransporter().sendMail({
-		from: `"Primal Printing" <${process.env.GMAIL_USER}>`,
+		from: fromAddress(),
 		to,
 		subject: hasTimeslots
 			? `Payment Received — ${orderNumber} — Select Your Pickup Slot`
@@ -189,28 +171,18 @@ export async function sendPaymentConfirmationEmail(params: {
 	const { to, customerName, orderNumber, files, pricing, hasTimeslots } =
 		params;
 
-	const contact = await getContactInfo();
-	const ordersUrl = `${process.env.NEXT_PUBLIC_BASE_URL || ""}/my-orders`;
+	const common = await buildCommonLocals(customerName);
 
 	const html = renderTemplate("paymentConfirmation", {
-		customerName: customerName || "Customer",
+		...common,
 		orderNumber,
-		files: files.map((f) => ({
-			...f,
-			colorLabel: f.colorMode === "COLOR" ? "Colour" : "B&W",
-			sidedLabel: f.doubleSided ? "Double-sided" : "Single-sided",
-		})),
-		subtotal: formatCents(pricing?.subtotal),
-		tax: formatCents(pricing?.tax),
-		total: formatCents(pricing?.total),
+		files: formatFilesForTemplate(files),
+		...formatPricingForTemplate(pricing),
 		hasTimeslots,
-		ordersUrl,
-		contactEmail: contact.email,
-		contactPhone: contact.phone,
 	});
 
 	await getTransporter().sendMail({
-		from: `"Primal Printing" <${process.env.GMAIL_USER}>`,
+		from: fromAddress(),
 		to,
 		subject: `Payment Confirmed — ${orderNumber} — ${hasTimeslots ? "Select Your Pickup Slot" : "We'll Notify You When Timeslots Are Ready"}`,
 		html,
@@ -229,28 +201,20 @@ export async function sendTimeslotsAvailableEmail(params: {
 }): Promise<void> {
 	const { to, customerName, orders } = params;
 
-	const contact = await getContactInfo();
-	const ordersUrl = `${process.env.NEXT_PUBLIC_BASE_URL || ""}/my-orders`;
+	const common = await buildCommonLocals(customerName);
 
 	const html = renderTemplate("timeslotsAvailable", {
-		customerName: customerName || "Customer",
+		...common,
 		orders: orders.map((o) => ({
 			...o,
-			files: o.files.map((f) => ({
-				...f,
-				colorLabel: f.colorMode === "COLOR" ? "Colour" : "B&W",
-				sidedLabel: f.doubleSided ? "Double-sided" : "Single-sided",
-			})),
+			files: formatFilesForTemplate(o.files),
 		})),
-		ordersUrl,
-		contactEmail: contact.email,
-		contactPhone: contact.phone,
 	});
 
 	await getTransporter().sendMail({
-		from: `"Primal Printing" <${process.env.GMAIL_USER}>`,
+		from: fromAddress(),
 		to,
-		subject: `Pickup Timeslots Available — Select Your Slot Now`,
+		subject: "Pickup Timeslots Available — Select Your Slot Now",
 		html,
 	});
 }
@@ -260,4 +224,44 @@ export async function sendTimeslotsAvailableEmail(params: {
 function formatCents(cents: number | undefined | null): string {
 	if (cents == null) return "$0.00";
 	return `$${(cents / 100).toFixed(2)}`;
+}
+
+/** Map raw OrderFile[] into template-friendly objects with display labels. */
+function formatFilesForTemplate(
+	files: OrderFile[],
+): Record<string, unknown>[] {
+	return files.map((f) => ({
+		...f,
+		colorLabel: f.colorMode === "COLOR" ? "Colour" : "B&W",
+		sidedLabel: f.doubleSided ? "Double-sided" : "Single-sided",
+	}));
+}
+
+/** Format a PricingInfo into display-ready strings. */
+function formatPricingForTemplate(pricing: PricingInfo | undefined): {
+	subtotal: string;
+	tax: string;
+	total: string;
+} {
+	return {
+		subtotal: formatCents(pricing?.subtotal),
+		tax: formatCents(pricing?.tax),
+		total: formatCents(pricing?.total),
+	};
+}
+
+/** Build the common template locals shared by every email. */
+async function buildCommonLocals(customerName: string) {
+	const contact = await getContactInfo();
+	return {
+		customerName: customerName || "Customer",
+		ordersUrl: `${process.env.NEXT_PUBLIC_BASE_URL || ""}/my-orders`,
+		contactEmail: contact.email,
+		contactPhone: contact.phone,
+	};
+}
+
+/** Build the "from" address used by every outgoing email. */
+function fromAddress(): string {
+	return `"Primal Printing" <${process.env.GMAIL_USER}>`;
 }

--- a/lib/templates/_mixins.pug
+++ b/lib/templates/_mixins.pug
@@ -1,0 +1,47 @@
+//- ── Shared mixins for email templates ──────────────────────────────────
+
+//- Render a list of order files with their details.
+mixin fileList(files)
+  .section
+    h2 Order Items
+    each file in files
+      .file-item
+        .file-name #{file.fileName}
+        .file-details #{file.pageCount} pages · #{file.copies} #{file.copies === 1 ? 'copy' : 'copies'} · #{file.colorLabel} · #{file.paperSize} · #{file.sidedLabel}
+
+//- Render the pricing breakdown table.
+mixin pricingTable(subtotal, tax, total)
+  .section
+    h2 Pricing
+    table.pricing-table
+      tr
+        td.label Subtotal
+        td.value #{subtotal}
+      tr
+        td.label Tax
+        td.value #{tax}
+      tr.total
+        td.label Total
+        td.value #{total}
+
+//- Render the contact info and footer.
+mixin contactAndFooter(contactEmail, contactPhone)
+  if contactEmail
+    p Email: #{contactEmail}
+  if contactPhone
+    p Phone: #{contactPhone}
+
+//- Render the "select timeslot" action or "coming soon" info box.
+mixin timeslotNextStep(hasTimeslots, ordersUrl)
+  if hasTimeslots
+    .action-box
+      h3 📅 Next Step: Select a Pickup Slot
+      p Pickup timeslots are available now! Head to your orders page to choose when you'd like to collect your prints.
+      p
+        a.btn(href=ordersUrl) Select Pickup Slot
+  else
+    .info-box
+      h3 ⏳ Pickup Timeslots Coming Soon
+      p There are no pickup timeslots available right now — don't worry! We'll send you another email as soon as timeslots are available so you can choose a pickup time.
+      if block
+        block

--- a/lib/templates/_styles.pug
+++ b/lib/templates/_styles.pug
@@ -1,0 +1,35 @@
+//- ── Shared base styles for all email templates ────────────────────────
+style.
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; padding: 0; background: #f5f5f5; }
+  .container { max-width: 600px; margin: 0 auto; background: #ffffff; }
+  .header { background: #1a1a2e; color: #ffffff; padding: 32px 24px; text-align: center; }
+  .header h1 { margin: 0; font-size: 24px; font-weight: 600; }
+  .header p { margin: 8px 0 0; opacity: 0.8; font-size: 14px; }
+  .content { padding: 24px; }
+  .section { margin-bottom: 24px; }
+  .section h2 { font-size: 16px; font-weight: 600; color: #1a1a2e; margin: 0 0 12px; border-bottom: 2px solid #e0e0e0; padding-bottom: 8px; }
+  .file-item { background: #f9f9f9; border-radius: 8px; padding: 12px 16px; margin-bottom: 8px; }
+  .file-name { font-weight: 600; margin-bottom: 4px; }
+  .file-details { font-size: 13px; color: #666; }
+  .pricing-table { width: 100%; border-collapse: collapse; }
+  .pricing-table td { padding: 6px 0; }
+  .pricing-table .label { color: #666; }
+  .pricing-table .value { text-align: right; font-weight: 500; }
+  .pricing-table .total td { border-top: 2px solid #1a1a2e; padding-top: 10px; font-weight: 700; font-size: 18px; }
+  .status-box { background: #e8f5e9; border-radius: 8px; padding: 16px; border-left: 4px solid #4caf50; margin: 16px 0; }
+  .status-box h3 { margin: 0 0 8px; color: #2e7d32; }
+  .status-box p { margin: 4px 0; }
+  .action-box { background: #e3f2fd; border-radius: 8px; padding: 16px; border-left: 4px solid #1976d2; margin: 16px 0; }
+  .action-box h3 { margin: 0 0 8px; color: #1565c0; }
+  .action-box p { margin: 4px 0; }
+  .info-box { background: #fff3e0; border-radius: 8px; padding: 16px; border-left: 4px solid #ff9800; margin: 16px 0; }
+  .info-box h3 { margin: 0 0 8px; color: #e65100; }
+  .info-box p { margin: 4px 0; }
+  .pickup-box { background: #e8f5e9; border-radius: 8px; padding: 16px; border-left: 4px solid #4caf50; }
+  .pickup-box h3 { margin: 0 0 8px; color: #2e7d32; }
+  .pickup-box p { margin: 4px 0; }
+  .order-list { margin: 16px 0; }
+  .order-item { background: #f9f9f9; border-radius: 8px; padding: 12px 16px; margin-bottom: 8px; }
+  .order-number { font-weight: 600; }
+  .btn { display: inline-block; background: #1a1a2e; color: #ffffff; text-decoration: none; padding: 12px 24px; border-radius: 6px; font-weight: 600; margin-top: 8px; }
+  .footer { padding: 24px; text-align: center; font-size: 13px; color: #999; border-top: 1px solid #eee; }

--- a/lib/templates/orderConfirmation.pug
+++ b/lib/templates/orderConfirmation.pug
@@ -1,29 +1,11 @@
+include _mixins
+
 doctype html
 html
   head
     meta(charset="utf-8")
     meta(name="viewport" content="width=device-width, initial-scale=1.0")
-    style.
-      body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; padding: 0; background: #f5f5f5; }
-      .container { max-width: 600px; margin: 0 auto; background: #ffffff; }
-      .header { background: #1a1a2e; color: #ffffff; padding: 32px 24px; text-align: center; }
-      .header h1 { margin: 0; font-size: 24px; font-weight: 600; }
-      .header p { margin: 8px 0 0; opacity: 0.8; font-size: 14px; }
-      .content { padding: 24px; }
-      .section { margin-bottom: 24px; }
-      .section h2 { font-size: 16px; font-weight: 600; color: #1a1a2e; margin: 0 0 12px; border-bottom: 2px solid #e0e0e0; padding-bottom: 8px; }
-      .file-item { background: #f9f9f9; border-radius: 8px; padding: 12px 16px; margin-bottom: 8px; }
-      .file-name { font-weight: 600; margin-bottom: 4px; }
-      .file-details { font-size: 13px; color: #666; }
-      .pricing-table { width: 100%; border-collapse: collapse; }
-      .pricing-table td { padding: 6px 0; }
-      .pricing-table .label { color: #666; }
-      .pricing-table .value { text-align: right; font-weight: 500; }
-      .pricing-table .total td { border-top: 2px solid #1a1a2e; padding-top: 10px; font-weight: 700; font-size: 18px; }
-      .pickup-box { background: #e8f5e9; border-radius: 8px; padding: 16px; border-left: 4px solid #4caf50; }
-      .pickup-box h3 { margin: 0 0 8px; color: #2e7d32; }
-      .pickup-box p { margin: 4px 0; }
-      .footer { padding: 24px; text-align: center; font-size: 13px; color: #999; border-top: 1px solid #eee; }
+    include _styles
   body
     .container
       .header
@@ -35,25 +17,9 @@ html
 
         p Your order has been confirmed and payment received. Here's your order summary:
 
-        .section
-          h2 Order Items
-          each file in files
-            .file-item
-              .file-name #{file.fileName}
-              .file-details #{file.pageCount} pages · #{file.copies} #{file.copies === 1 ? 'copy' : 'copies'} · #{file.colorLabel} · #{file.paperSize} · #{file.sidedLabel}
+        +fileList(files)
 
-        .section
-          h2 Pricing
-          table.pricing-table
-            tr
-              td.label Subtotal
-              td.value #{subtotal}
-            tr
-              td.label Tax
-              td.value #{tax}
-            tr.total
-              td.label Total
-              td.value #{total}
+        +pricingTable(subtotal, tax, total)
 
         .section
           .pickup-box
@@ -70,10 +36,7 @@ html
                 | #{pickupLabel}
 
         p If you have any questions, please contact us:
-        if contactEmail
-          p Email: #{contactEmail}
-        if contactPhone
-          p Phone: #{contactPhone}
+        +contactAndFooter(contactEmail, contactPhone)
 
       .footer
         p Primal Printing — Thank you for your order!

--- a/lib/templates/paymentConfirmation.pug
+++ b/lib/templates/paymentConfirmation.pug
@@ -1,36 +1,11 @@
+include _mixins
+
 doctype html
 html
   head
     meta(charset="utf-8")
     meta(name="viewport" content="width=device-width, initial-scale=1.0")
-    style.
-      body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; padding: 0; background: #f5f5f5; }
-      .container { max-width: 600px; margin: 0 auto; background: #ffffff; }
-      .header { background: #1a1a2e; color: #ffffff; padding: 32px 24px; text-align: center; }
-      .header h1 { margin: 0; font-size: 24px; font-weight: 600; }
-      .header p { margin: 8px 0 0; opacity: 0.8; font-size: 14px; }
-      .content { padding: 24px; }
-      .section { margin-bottom: 24px; }
-      .section h2 { font-size: 16px; font-weight: 600; color: #1a1a2e; margin: 0 0 12px; border-bottom: 2px solid #e0e0e0; padding-bottom: 8px; }
-      .file-item { background: #f9f9f9; border-radius: 8px; padding: 12px 16px; margin-bottom: 8px; }
-      .file-name { font-weight: 600; margin-bottom: 4px; }
-      .file-details { font-size: 13px; color: #666; }
-      .pricing-table { width: 100%; border-collapse: collapse; }
-      .pricing-table td { padding: 6px 0; }
-      .pricing-table .label { color: #666; }
-      .pricing-table .value { text-align: right; font-weight: 500; }
-      .pricing-table .total td { border-top: 2px solid #1a1a2e; padding-top: 10px; font-weight: 700; font-size: 18px; }
-      .status-box { background: #e8f5e9; border-radius: 8px; padding: 16px; border-left: 4px solid #4caf50; margin: 16px 0; }
-      .status-box h3 { margin: 0 0 8px; color: #2e7d32; }
-      .status-box p { margin: 4px 0; }
-      .action-box { background: #e3f2fd; border-radius: 8px; padding: 16px; border-left: 4px solid #1976d2; margin: 16px 0; }
-      .action-box h3 { margin: 0 0 8px; color: #1565c0; }
-      .action-box p { margin: 4px 0; }
-      .info-box { background: #fff3e0; border-radius: 8px; padding: 16px; border-left: 4px solid #ff9800; margin: 16px 0; }
-      .info-box h3 { margin: 0 0 8px; color: #e65100; }
-      .info-box p { margin: 4px 0; }
-      .btn { display: inline-block; background: #1a1a2e; color: #ffffff; text-decoration: none; padding: 12px 24px; border-radius: 6px; font-weight: 600; margin-top: 8px; }
-      .footer { padding: 24px; text-align: center; font-size: 13px; color: #999; border-top: 1px solid #eee; }
+    include _styles
   body
     .container
       .header
@@ -46,43 +21,15 @@ html
           h3 ✅ Payment Confirmed
           p Your payment of #{total} has been processed successfully.
 
-        .section
-          h2 Order Items
-          each file in files
-            .file-item
-              .file-name #{file.fileName}
-              .file-details #{file.pageCount} pages · #{file.copies} #{file.copies === 1 ? 'copy' : 'copies'} · #{file.colorLabel} · #{file.paperSize} · #{file.sidedLabel}
+        +fileList(files)
 
-        .section
-          h2 Pricing
-          table.pricing-table
-            tr
-              td.label Subtotal
-              td.value #{subtotal}
-            tr
-              td.label Tax
-              td.value #{tax}
-            tr.total
-              td.label Total
-              td.value #{total}
+        +pricingTable(subtotal, tax, total)
 
-        if hasTimeslots
-          .action-box
-            h3 📅 Next Step: Select a Pickup Slot
-            p Pickup timeslots are available now! Head to your orders page to choose when you'd like to collect your prints.
-            p
-              a.btn(href=ordersUrl) Select Pickup Slot
-        else
-          .info-box
-            h3 ⏳ Pickup Timeslots Coming Soon
-            p There are no pickup timeslots available right now — don't worry! We'll send you another email as soon as timeslots are available so you can choose a pickup time.
-            p In the meantime, we'll get started on printing your order.
+        +timeslotNextStep(hasTimeslots, ordersUrl)
+          p In the meantime, we'll get started on printing your order.
 
         p If you have any questions, please contact us:
-        if contactEmail
-          p Email: #{contactEmail}
-        if contactPhone
-          p Phone: #{contactPhone}
+        +contactAndFooter(contactEmail, contactPhone)
 
       .footer
         p Primal Printing — Thank you for your order!

--- a/lib/templates/paymentPendingVerification.pug
+++ b/lib/templates/paymentPendingVerification.pug
@@ -1,36 +1,11 @@
+include _mixins
+
 doctype html
 html
   head
     meta(charset="utf-8")
     meta(name="viewport" content="width=device-width, initial-scale=1.0")
-    style.
-      body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; padding: 0; background: #f5f5f5; }
-      .container { max-width: 600px; margin: 0 auto; background: #ffffff; }
-      .header { background: #1a1a2e; color: #ffffff; padding: 32px 24px; text-align: center; }
-      .header h1 { margin: 0; font-size: 24px; font-weight: 600; }
-      .header p { margin: 8px 0 0; opacity: 0.8; font-size: 14px; }
-      .content { padding: 24px; }
-      .section { margin-bottom: 24px; }
-      .section h2 { font-size: 16px; font-weight: 600; color: #1a1a2e; margin: 0 0 12px; border-bottom: 2px solid #e0e0e0; padding-bottom: 8px; }
-      .file-item { background: #f9f9f9; border-radius: 8px; padding: 12px 16px; margin-bottom: 8px; }
-      .file-name { font-weight: 600; margin-bottom: 4px; }
-      .file-details { font-size: 13px; color: #666; }
-      .pricing-table { width: 100%; border-collapse: collapse; }
-      .pricing-table td { padding: 6px 0; }
-      .pricing-table .label { color: #666; }
-      .pricing-table .value { text-align: right; font-weight: 500; }
-      .pricing-table .total td { border-top: 2px solid #1a1a2e; padding-top: 10px; font-weight: 700; font-size: 18px; }
-      .status-box { background: #e8f5e9; border-radius: 8px; padding: 16px; border-left: 4px solid #4caf50; margin: 16px 0; }
-      .status-box h3 { margin: 0 0 8px; color: #2e7d32; }
-      .status-box p { margin: 4px 0; }
-      .action-box { background: #e3f2fd; border-radius: 8px; padding: 16px; border-left: 4px solid #1976d2; margin: 16px 0; }
-      .action-box h3 { margin: 0 0 8px; color: #1565c0; }
-      .action-box p { margin: 4px 0; }
-      .info-box { background: #fff3e0; border-radius: 8px; padding: 16px; border-left: 4px solid #ff9800; margin: 16px 0; }
-      .info-box h3 { margin: 0 0 8px; color: #e65100; }
-      .info-box p { margin: 4px 0; }
-      .btn { display: inline-block; background: #1a1a2e; color: #ffffff; text-decoration: none; padding: 12px 24px; border-radius: 6px; font-weight: 600; margin-top: 8px; }
-      .footer { padding: 24px; text-align: center; font-size: 13px; color: #999; border-top: 1px solid #eee; }
+    include _styles
   body
     .container
       .header
@@ -47,43 +22,15 @@ html
           p Your payment of #{total} has been received. You can now proceed to select a pickup time.
 
         if files && files.length
-          .section
-            h2 Order Items
-            each file in files
-              .file-item
-                .file-name #{file.fileName}
-                .file-details #{file.pageCount} pages · #{file.copies} #{file.copies === 1 ? 'copy' : 'copies'} · #{file.colorLabel} · #{file.paperSize} · #{file.sidedLabel}
+          +fileList(files)
 
-          .section
-            h2 Pricing
-            table.pricing-table
-              tr
-                td.label Subtotal
-                td.value #{subtotal}
-              tr
-                td.label Tax
-                td.value #{tax}
-              tr.total
-                td.label Total
-                td.value #{total}
+          +pricingTable(subtotal, tax, total)
 
-        if hasTimeslots
-          .action-box
-            h3 📅 Next Step: Select a Pickup Slot
-            p Pickup timeslots are available now! Head to your orders page to choose when you'd like to collect your prints.
-            p
-              a.btn(href=ordersUrl) Select Pickup Slot
-        else
-          .info-box
-            h3 ⏳ Pickup Timeslots Coming Soon
-            p There are no pickup timeslots available right now — don't worry! We'll send you another email as soon as timeslots are available so you can choose a pickup time.
-            p In the meantime, sit tight and we'll get your order ready.
+        +timeslotNextStep(hasTimeslots, ordersUrl)
+          p In the meantime, sit tight and we'll get your order ready.
 
         p If you have any questions about your payment or order, please contact us:
-        if contactEmail
-          p Email: #{contactEmail}
-        if contactPhone
-          p Phone: #{contactPhone}
+        +contactAndFooter(contactEmail, contactPhone)
 
       .footer
         p Primal Printing — Thank you for your order!

--- a/lib/templates/paymentPendingVerification.pug
+++ b/lib/templates/paymentPendingVerification.pug
@@ -10,6 +10,16 @@ html
       .header h1 { margin: 0; font-size: 24px; font-weight: 600; }
       .header p { margin: 8px 0 0; opacity: 0.8; font-size: 14px; }
       .content { padding: 24px; }
+      .section { margin-bottom: 24px; }
+      .section h2 { font-size: 16px; font-weight: 600; color: #1a1a2e; margin: 0 0 12px; border-bottom: 2px solid #e0e0e0; padding-bottom: 8px; }
+      .file-item { background: #f9f9f9; border-radius: 8px; padding: 12px 16px; margin-bottom: 8px; }
+      .file-name { font-weight: 600; margin-bottom: 4px; }
+      .file-details { font-size: 13px; color: #666; }
+      .pricing-table { width: 100%; border-collapse: collapse; }
+      .pricing-table td { padding: 6px 0; }
+      .pricing-table .label { color: #666; }
+      .pricing-table .value { text-align: right; font-weight: 500; }
+      .pricing-table .total td { border-top: 2px solid #1a1a2e; padding-top: 10px; font-weight: 700; font-size: 18px; }
       .status-box { background: #e8f5e9; border-radius: 8px; padding: 16px; border-left: 4px solid #4caf50; margin: 16px 0; }
       .status-box h3 { margin: 0 0 8px; color: #2e7d32; }
       .status-box p { margin: 4px 0; }
@@ -35,6 +45,27 @@ html
         .status-box
           h3 ✅ Payment Confirmed
           p Your payment of #{total} has been received. You can now proceed to select a pickup time.
+
+        if files && files.length
+          .section
+            h2 Order Items
+            each file in files
+              .file-item
+                .file-name #{file.fileName}
+                .file-details #{file.pageCount} pages · #{file.copies} #{file.copies === 1 ? 'copy' : 'copies'} · #{file.colorLabel} · #{file.paperSize} · #{file.sidedLabel}
+
+          .section
+            h2 Pricing
+            table.pricing-table
+              tr
+                td.label Subtotal
+                td.value #{subtotal}
+              tr
+                td.label Tax
+                td.value #{tax}
+              tr.total
+                td.label Total
+                td.value #{total}
 
         if hasTimeslots
           .action-box

--- a/lib/templates/timeslotsAvailable.pug
+++ b/lib/templates/timeslotsAvailable.pug
@@ -1,26 +1,11 @@
+include _mixins
+
 doctype html
 html
   head
     meta(charset="utf-8")
     meta(name="viewport" content="width=device-width, initial-scale=1.0")
-    style.
-      body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; padding: 0; background: #f5f5f5; }
-      .container { max-width: 600px; margin: 0 auto; background: #ffffff; }
-      .header { background: #1a1a2e; color: #ffffff; padding: 32px 24px; text-align: center; }
-      .header h1 { margin: 0; font-size: 24px; font-weight: 600; }
-      .header p { margin: 8px 0 0; opacity: 0.8; font-size: 14px; }
-      .content { padding: 24px; }
-      .action-box { background: #e8f5e9; border-radius: 8px; padding: 16px; border-left: 4px solid #4caf50; margin: 16px 0; }
-      .action-box h3 { margin: 0 0 8px; color: #2e7d32; }
-      .action-box p { margin: 4px 0; }
-      .order-list { margin: 16px 0; }
-      .order-item { background: #f9f9f9; border-radius: 8px; padding: 12px 16px; margin-bottom: 8px; }
-      .order-number { font-weight: 600; }
-      .file-item { background: #f0f0f0; border-radius: 6px; padding: 8px 12px; margin: 4px 0 4px 8px; }
-      .file-name { font-weight: 600; font-size: 13px; margin-bottom: 2px; }
-      .file-details { font-size: 12px; color: #666; }
-      .btn { display: inline-block; background: #1a1a2e; color: #ffffff; text-decoration: none; padding: 12px 24px; border-radius: 6px; font-weight: 600; margin-top: 8px; }
-      .footer { padding: 24px; text-align: center; font-size: 13px; color: #999; border-top: 1px solid #eee; }
+    include _styles
   body
     .container
       .header
@@ -49,10 +34,7 @@ html
             a.btn(href=ordersUrl) Select Pickup Slot
 
         p If you have any questions, please contact us:
-        if contactEmail
-          p Email: #{contactEmail}
-        if contactPhone
-          p Phone: #{contactPhone}
+        +contactAndFooter(contactEmail, contactPhone)
 
       .footer
         p Primal Printing — Thank you for your order!

--- a/lib/templates/timeslotsAvailable.pug
+++ b/lib/templates/timeslotsAvailable.pug
@@ -16,6 +16,9 @@ html
       .order-list { margin: 16px 0; }
       .order-item { background: #f9f9f9; border-radius: 8px; padding: 12px 16px; margin-bottom: 8px; }
       .order-number { font-weight: 600; }
+      .file-item { background: #f0f0f0; border-radius: 6px; padding: 8px 12px; margin: 4px 0 4px 8px; }
+      .file-name { font-weight: 600; font-size: 13px; margin-bottom: 2px; }
+      .file-details { font-size: 12px; color: #666; }
       .btn { display: inline-block; background: #1a1a2e; color: #ffffff; text-decoration: none; padding: 12px 24px; border-radius: 6px; font-weight: 600; margin-top: 8px; }
       .footer { padding: 24px; text-align: center; font-size: 13px; color: #999; border-top: 1px solid #eee; }
   body
@@ -33,6 +36,11 @@ html
           each order in orders
             .order-item
               span.order-number Order ##{order.orderNumber}
+              if order.files && order.files.length
+                each file in order.files
+                  .file-item
+                    .file-name #{file.fileName}
+                    .file-details #{file.pageCount} pages · #{file.copies} #{file.copies === 1 ? 'copy' : 'copies'} · #{file.colorLabel} · #{file.paperSize} · #{file.sidedLabel}
 
         .action-box
           h3 📅 Select Your Pickup Slot


### PR DESCRIPTION
## Summary

Previously, the **bank transfer confirmation** and **timeslots available** emails only showed minimal information (total amount or order number). This PR updates all four email templates so customers consistently receive a complete confirmation of what they ordered.

### Changes

**Templates updated:**
- `paymentPendingVerification.pug` — Now includes the full order items list (file name, pages, copies, colour mode, paper size, sided) and a pricing breakdown (subtotal, tax, total), matching the existing `orderConfirmation.pug` and `paymentConfirmation.pug` templates.
- `timeslotsAvailable.pug` — Now shows file details under each order number so customers are reminded what they ordered when selecting a pickup slot.

**Email functions updated:**
- `sendBankTransferReceivedEmail` — Now accepts `files: OrderFile[]` and `pricing: PricingInfo` instead of just `total: number`.
- `sendTimeslotsAvailableEmail` — Now accepts `files: OrderFile[]` per order in the `orders` array.

**Consumer routes updated:**
- `submit-bank-transfer/route.ts` — Passes `files` and `pricing` to the email function.
- `resend-confirmation/route.ts` — Passes `files` and `pricing` for bank transfer resends.
- `notify-timeslots/route.ts` — Passes `files` per order when grouping by customer.

### Result
All four email types now show consistent file details:
| Email | Before | After |
|-------|--------|-------|
| Order Confirmation | ✅ Had file details | ✅ No change |
| Payment Confirmation (Stripe) | ✅ Had file details | ✅ No change |
| Bank Transfer Received | ❌ Only total amount | ✅ Full file list + pricing |
| Timeslots Available | ❌ Only order numbers | ✅ File details per order |
