### PR TITLE
feat: timeslot change notifications, re-selection & daily order summary

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -23,6 +23,8 @@ on:
   schedule:
     # Every day at 03:00 UTC
     - cron: "0 3 * * *" # schedule-id: daily
+    # Every day at 18:00 UTC (morning NZT next day)
+    - cron: "0 18 * * *" # schedule-id: evening
 
   # Allow manual triggering from the Actions tab.
   workflow_dispatch:
@@ -35,6 +37,7 @@ on:
         options:
           - all
           - /api/cron/expire-orders
+          - /api/cron/daily-order-summary
 
 jobs:
   run:
@@ -63,6 +66,10 @@ jobs:
             endpoint: /api/cron/expire-orders
             method: POST
             schedule: "0 3 * * *"
+          - name: Daily order summary
+            endpoint: /api/cron/daily-order-summary
+            method: POST
+            schedule: "0 18 * * *"
 
     name: ${{ matrix.name }}
 

--- a/app/(payload)/api/auth/[...nextauth]/route.ts
+++ b/app/(payload)/api/auth/[...nextauth]/route.ts
@@ -114,4 +114,5 @@ const authOptions: NextAuthOptions = {
 };
 
 const handler = NextAuth(authOptions);
+
 export { handler as GET, handler as POST };

--- a/app/api/cron/daily-order-summary/route.ts
+++ b/app/api/cron/daily-order-summary/route.ts
@@ -38,26 +38,29 @@ export async function POST(request: NextRequest) {
 		});
 
 		const totalOrders = orders.length;
-		const totalRevenueCents = orders.reduce(
-			(sum, o) => sum + ((o.pricing as { total?: number })?.total || 0),
-			0,
-		);
-		const pickupSelected = orders.filter((o) => o.pickupTimeslot).length;
-		const awaitingPickup = totalOrders - pickupSelected;
+		const needsPickupSelection = orders.filter(
+			(o) => o.status === "PAID" && !o.pickupTimeslot,
+		).length;
+		const needsPrinting = orders.filter(
+			(o) => o.status === "AWAITING_PICKUP",
+		).length;
+		const pendingVerification = orders.filter(
+			(o) => o.status === "PENDING_VERIFICATION",
+		).length;
 
 		await notifyDailyOrderSummary({
 			totalOrders,
-			totalRevenueCents,
-			awaitingPickup,
-			pickupSelected,
+			needsPickupSelection,
+			needsPrinting,
+			pendingVerification,
 		});
 
 		return NextResponse.json({
 			success: true,
 			totalOrders,
-			totalRevenueCents,
-			awaitingPickup,
-			pickupSelected,
+			needsPickupSelection,
+			needsPrinting,
+			pendingVerification,
 			message: `Daily summary posted: ${totalOrders} order(s).`,
 		});
 	} catch (error) {

--- a/app/api/cron/daily-order-summary/route.ts
+++ b/app/api/cron/daily-order-summary/route.ts
@@ -1,0 +1,70 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { notifyDailyOrderSummary } from "../../../../lib/discord";
+import { getPayloadClient } from "../../../../lib/payload";
+
+/**
+ * POST /api/cron/daily-order-summary
+ *
+ * Cron job that posts a daily rollup of paid orders to Discord.
+ * Intended to run once per day (e.g. 18:00 UTC / morning NZT).
+ *
+ * Protected by CRON_SECRET header.
+ */
+export async function POST(request: NextRequest) {
+	const authHeader = request.headers.get("authorization");
+	const expectedSecret = process.env.CRON_SECRET;
+
+	if (!expectedSecret || authHeader !== `Bearer ${expectedSecret}`) {
+		return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+	}
+
+	try {
+		const payload = await getPayloadClient();
+
+		// Today's date range (UTC)
+		const now = new Date();
+		const startOfDay = new Date(now);
+		startOfDay.setUTCHours(0, 0, 0, 0);
+
+		const { docs: orders } = await payload.find({
+			collection: "orders",
+			where: {
+				paidAt: {
+					greater_than_equal: startOfDay.toISOString(),
+					less_than_equal: now.toISOString(),
+				},
+			},
+			limit: 0,
+		});
+
+		const totalOrders = orders.length;
+		const totalRevenueCents = orders.reduce(
+			(sum, o) => sum + ((o.pricing as { total?: number })?.total || 0),
+			0,
+		);
+		const pickupSelected = orders.filter((o) => o.pickupTimeslot).length;
+		const awaitingPickup = totalOrders - pickupSelected;
+
+		await notifyDailyOrderSummary({
+			totalOrders,
+			totalRevenueCents,
+			awaitingPickup,
+			pickupSelected,
+		});
+
+		return NextResponse.json({
+			success: true,
+			totalOrders,
+			totalRevenueCents,
+			awaitingPickup,
+			pickupSelected,
+			message: `Daily summary posted: ${totalOrders} order(s).`,
+		});
+	} catch (error) {
+		console.error("Error in daily-order-summary cron:", error);
+		return NextResponse.json(
+			{ error: "Failed to generate daily summary." },
+			{ status: 500 },
+		);
+	}
+}

--- a/app/api/shop/[orderId]/select-timeslot/route.ts
+++ b/app/api/shop/[orderId]/select-timeslot/route.ts
@@ -9,8 +9,9 @@ type RouteContext = { params: Promise<{ orderId: string }> };
 /**
  * POST /api/orders/:orderId/select-timeslot
  *
- * Customer selects a pickup timeslot for a PAID order.
- * Transitions: PAID → AWAITING_PICKUP
+ * Customer selects (or changes) a pickup timeslot.
+ * - PAID → AWAITING_PICKUP (first selection)
+ * - AWAITING_PICKUP → AWAITING_PICKUP (re-selection / change)
  * Triggers order confirmation email with pickup details.
  *
  * Body: `{ "timeslotId": "..." }`
@@ -54,10 +55,10 @@ export async function POST(request: NextRequest, context: RouteContext) {
 			return NextResponse.json({ error: "Order not found." }, { status: 404 });
 		}
 
-		if (order.status !== "PAID") {
+		if (order.status !== "PAID" && order.status !== "AWAITING_PICKUP") {
 			return NextResponse.json(
 				{
-					error: `Cannot select timeslot for order in ${order.status} status. Order must be PAID.`,
+					error: `Cannot select timeslot for order in ${order.status} status. Order must be PAID or AWAITING_PICKUP.`,
 				},
 				{ status: 400 },
 			);
@@ -76,14 +77,20 @@ export async function POST(request: NextRequest, context: RouteContext) {
 			);
 		}
 
-		// Transition to AWAITING_PICKUP
+		const isChangingTimeslot = order.status === "AWAITING_PICKUP";
+
+		// Update the order — only transition status if coming from PAID
+		const updateData: Record<string, unknown> = {
+			pickupTimeslot: timeslotId,
+		};
+		if (!isChangingTimeslot) {
+			updateData.status = "AWAITING_PICKUP";
+		}
+
 		const updated = await payload.update({
 			collection: "orders",
 			id: orderId,
-			data: {
-				status: "AWAITING_PICKUP",
-				pickupTimeslot: timeslotId,
-			},
+			data: updateData,
 		});
 
 		// Notify admin via Discord so they can prepare the order
@@ -137,7 +144,9 @@ export async function POST(request: NextRequest, context: RouteContext) {
 				status: updated.status,
 				pickupTimeslot: timeslot,
 			},
-			message: "Pickup timeslot confirmed. Confirmation email sent.",
+			message: isChangingTimeslot
+				? "Pickup timeslot updated. Confirmation email sent."
+				: "Pickup timeslot confirmed. Confirmation email sent.",
 		});
 	} catch (error) {
 		console.error("Error selecting timeslot:", error);

--- a/collections/Timeslots.ts
+++ b/collections/Timeslots.ts
@@ -1,4 +1,6 @@
-import type { CollectionConfig } from "payload";
+import type { CollectionAfterChangeHook, CollectionConfig } from "payload";
+import { sendTimeslotChangedEmail } from "../lib/email";
+import { getPayloadClient } from "../lib/payload";
 
 /**
  * Timeslots collection – admin-defined pickup windows that customers can book.
@@ -9,6 +11,97 @@ import type { CollectionConfig } from "payload";
  *
  * Relationship is one-to-many (one timeslot → many orders) with no limit.
  */
+
+// ── afterChange hook: notify customers when timeslot dates change ────────
+const notifyOnTimeslotChange: CollectionAfterChangeHook = async ({
+	doc,
+	previousDoc,
+	operation,
+}) => {
+	// Only run on updates where a previous doc exists
+	if (operation !== "update" || !previousDoc) return doc;
+
+	const dateChanged = previousDoc.date !== doc.date;
+	const startTimeChanged = previousDoc.startTime !== doc.startTime;
+	const endTimeChanged = previousDoc.endTime !== doc.endTime;
+
+	// Nothing relevant changed — skip
+	if (!dateChanged && !startTimeChanged && !endTimeChanged) return doc;
+
+	const previous = {
+		date: (previousDoc.date as string) || "",
+		startTime: previousDoc.startTime as string,
+		endTime: previousDoc.endTime as string,
+		label: (previousDoc.label as string) || "",
+	};
+
+	const updated = {
+		date: (doc.date as string) || "",
+		startTime: doc.startTime as string,
+		endTime: doc.endTime as string,
+		label: (doc.label as string) || "",
+	};
+
+	// Fire-and-forget so the admin UI isn't blocked
+	void (async () => {
+		try {
+			const payload = await getPayloadClient();
+
+			// Find all orders that reference this timeslot
+			const { docs: orders } = await payload.find({
+				collection: "orders",
+				where: { pickupTimeslot: { equals: doc.id } },
+				depth: 1, // populate the customer relationship
+				limit: 0, // no limit — fetch all
+			});
+
+			if (orders.length === 0) return;
+
+			// Send an email per order (each may belong to a different customer)
+			await Promise.allSettled(
+				orders.map((order) => {
+					const customer = order.customer as {
+						email?: string;
+						name?: string;
+					} | null;
+
+					if (!customer?.email) return Promise.resolve();
+
+					return sendTimeslotChangedEmail({
+						to: customer.email,
+						customerName: customer.name || "Customer",
+						orderNumber: order.orderNumber,
+						files: (order.files || []) as {
+							fileName: string;
+							pageCount: number;
+							copies: number;
+							colorMode: string;
+							paperSize: string;
+							doubleSided: boolean;
+						}[],
+						pricing: order.pricing as
+							| { subtotal: number; tax: number; total: number }
+							| undefined,
+						previous,
+						updated,
+					});
+				}),
+			);
+
+			console.log(
+				`[Timeslots] Notified ${orders.length} order(s) about timeslot ${doc.id} change`,
+			);
+		} catch (error) {
+			console.error(
+				`[Timeslots] Failed to send timeslot-change emails for ${doc.id}:`,
+				error,
+			);
+		}
+	})();
+
+	return doc;
+};
+
 export const Timeslots: CollectionConfig = {
 	slug: "timeslots",
 	admin: {
@@ -24,6 +117,9 @@ export const Timeslots: CollectionConfig = {
 		create: ({ req }) => Boolean(req.user),
 		update: ({ req }) => Boolean(req.user),
 		delete: ({ req }) => Boolean(req.user),
+	},
+	hooks: {
+		afterChange: [notifyOnTimeslotChange],
 	},
 	fields: [
 		{

--- a/components/ordercontainer/OrderContainer.tsx
+++ b/components/ordercontainer/OrderContainer.tsx
@@ -290,45 +290,45 @@ const OrderContainerInner = ({
 										</Button>
 										{o.status !== OrderStatus.PAID &&
 											o.status !== OrderStatus.AWAITING_PICKUP && (
-											<Button
-												size="xs"
-												colorScheme="red"
-												variant="ghost"
-												onClick={async () => {
-													if (
-														!window.confirm(
-															`Delete order ${o.orderNumber}? This cannot be undone.`,
+												<Button
+													size="xs"
+													colorScheme="red"
+													variant="ghost"
+													onClick={async () => {
+														if (
+															!window.confirm(
+																`Delete order ${o.orderNumber}? This cannot be undone.`,
+															)
 														)
-													)
-														return;
-													try {
-														const res = await fetch(
-															`/api/shop/${o.id}/delete`,
-															{
-																method: "DELETE",
-															},
-														);
-														if (!res.ok) {
-															const data = await res.json();
-															throw new Error(
-																data.error || "Failed to delete.",
+															return;
+														try {
+															const res = await fetch(
+																`/api/shop/${o.id}/delete`,
+																{
+																	method: "DELETE",
+																},
+															);
+															if (!res.ok) {
+																const data = await res.json();
+																throw new Error(
+																	data.error || "Failed to delete.",
+																);
+															}
+															setPendingOrders((prev) =>
+																prev.filter((p) => p.id !== o.id),
+															);
+														} catch (err) {
+															window.alert(
+																err instanceof Error
+																	? err.message
+																	: "Failed to delete order.",
 															);
 														}
-														setPendingOrders((prev) =>
-															prev.filter((p) => p.id !== o.id),
-														);
-													} catch (err) {
-														window.alert(
-															err instanceof Error
-																? err.message
-																: "Failed to delete order.",
-														);
-													}
-												}}
-											>
-												Delete
-											</Button>
-										)}
+													}}
+												>
+													Delete
+												</Button>
+											)}
 									</Box>
 								</Box>
 							))}

--- a/components/ordercontainer/OrderContainer.tsx
+++ b/components/ordercontainer/OrderContainer.tsx
@@ -122,8 +122,12 @@ const OrderContainerInner = ({
 				setActiveOrderId(order.id);
 				setActiveOrderNumber(order.orderNumber);
 
-				// If pickupFor query param, force pickup step (if order is PAID)
-				if (pickupForOrderId && order.status === OrderStatus.PAID) {
+				// If pickupFor query param, force pickup step (if order is PAID or AWAITING_PICKUP)
+				if (
+					pickupForOrderId &&
+					(order.status === OrderStatus.PAID ||
+						order.status === OrderStatus.AWAITING_PICKUP)
+				) {
 					setOrderStep(OrderStep.PICKUP);
 				} else {
 					setOrderStep(statusToStep(order.status));
@@ -151,7 +155,8 @@ const OrderContainerInner = ({
 					(o: { status: string }) =>
 						o.status === OrderStatus.DRAFT ||
 						o.status === OrderStatus.AWAITING_PAYMENT ||
-						o.status === OrderStatus.PAID,
+						o.status === OrderStatus.PAID ||
+						o.status === OrderStatus.AWAITING_PICKUP,
 				);
 				setPendingOrders(pending);
 			} catch {
@@ -270,17 +275,21 @@ const OrderContainerInner = ({
 											colorScheme="blue"
 											onClick={() =>
 												router.push(
-													o.status === OrderStatus.PAID
+													o.status === OrderStatus.PAID ||
+														o.status === OrderStatus.AWAITING_PICKUP
 														? `/order?pickupFor=${o.id}`
 														: `/order?resume=${o.id}`,
 												)
 											}
 										>
-											{o.status === OrderStatus.PAID
-												? "Select Pickup"
-												: "Resume"}
+											{o.status === OrderStatus.AWAITING_PICKUP
+												? "Change Pickup"
+												: o.status === OrderStatus.PAID
+													? "Select Pickup"
+													: "Resume"}
 										</Button>
-										{o.status !== OrderStatus.PAID && (
+										{o.status !== OrderStatus.PAID &&
+											o.status !== OrderStatus.AWAITING_PICKUP && (
 											<Button
 												size="xs"
 												colorScheme="red"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,4 +6,4 @@ pre-commit:
 pre-push:
   jobs:
     - name: run ci tests
-      run: pnpm biome ci --changed --since=main
+      run: pnpm biome ci .

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,4 +6,4 @@ pre-commit:
 pre-push:
   jobs:
     - name: run ci tests
-      run: pnpm biome ci .
+      run: pnpm biome ci --changed --since=main

--- a/lib/discord.ts
+++ b/lib/discord.ts
@@ -102,40 +102,61 @@ export async function notifyBankTransferSubmitted(params: {
 }
 
 /**
- * Post a daily rollup of orders received today.
- * Summarises total count, revenue, and pickup status.
+ * Post a daily rollup of today's orders so admins know what needs attention.
  */
 export async function notifyDailyOrderSummary(params: {
 	totalOrders: number;
-	totalRevenueCents: number;
-	awaitingPickup: number;
-	pickupSelected: number;
+	needsPickupSelection: number;
+	needsPrinting: number;
+	pendingVerification: number;
 }): Promise<void> {
-	const { totalOrders, totalRevenueCents, awaitingPickup, pickupSelected } =
-		params;
+	const {
+		totalOrders,
+		needsPickupSelection,
+		needsPrinting,
+		pendingVerification,
+	} = params;
 
 	if (totalOrders === 0) return;
 
-	const revenue = `$${(totalRevenueCents / 100).toFixed(2)}`;
+	const actionNeeded =
+		needsPickupSelection + needsPrinting + pendingVerification;
+	const color = actionNeeded > 0 ? COLORS.WARNING : COLORS.INFO;
+
+	const fields: EmbedField[] = [];
+
+	if (pendingVerification > 0) {
+		fields.push({
+			name: "⏳ Pending Payment Verification",
+			value: String(pendingVerification),
+			inline: true,
+		});
+	}
+	if (needsPickupSelection > 0) {
+		fields.push({
+			name: "📍 Awaiting Pickup Selection",
+			value: String(needsPickupSelection),
+			inline: true,
+		});
+	}
+	if (needsPrinting > 0) {
+		fields.push({
+			name: "🖨️ Ready to Print",
+			value: String(needsPrinting),
+			inline: true,
+		});
+	}
 
 	await sendDiscordWebhook({
 		embeds: [
 			{
-				title: "📊 Daily Order Summary",
-				description: `**${totalOrders}** order${totalOrders !== 1 ? "s" : ""} paid today — **${revenue}** total revenue.`,
-				color: COLORS.INFO,
-				fields: [
-					{
-						name: "Awaiting Pickup Selection",
-						value: String(awaitingPickup),
-						inline: true,
-					},
-					{
-						name: "Pickup Selected",
-						value: String(pickupSelected),
-						inline: true,
-					},
-				],
+				title:
+					actionNeeded > 0
+						? "📋 Daily Order Summary — Action Needed"
+						: "📋 Daily Order Summary",
+				description: `**${totalOrders}** order${totalOrders !== 1 ? "s" : ""} paid today.${actionNeeded > 0 ? ` **${actionNeeded}** need${actionNeeded !== 1 ? "" : "s"} attention.` : " All orders are on track."}`,
+				color,
+				fields,
 				timestamp: new Date().toISOString(),
 			},
 		],

--- a/lib/discord.ts
+++ b/lib/discord.ts
@@ -114,19 +114,7 @@ export async function notifyDailyOrderSummary(params: {
 	const { totalOrders, totalRevenueCents, awaitingPickup, pickupSelected } =
 		params;
 
-	if (totalOrders === 0) {
-		await sendDiscordWebhook({
-			embeds: [
-				{
-					title: "📊 Daily Order Summary",
-					description: "No new paid orders today.",
-					color: COLORS.INFO,
-					timestamp: new Date().toISOString(),
-				},
-			],
-		});
-		return;
-	}
+	if (totalOrders === 0) return;
 
 	const revenue = `$${(totalRevenueCents / 100).toFixed(2)}`;
 

--- a/lib/discord.ts
+++ b/lib/discord.ts
@@ -102,6 +102,59 @@ export async function notifyBankTransferSubmitted(params: {
 }
 
 /**
+ * Post a daily rollup of orders received today.
+ * Summarises total count, revenue, and pickup status.
+ */
+export async function notifyDailyOrderSummary(params: {
+	totalOrders: number;
+	totalRevenueCents: number;
+	awaitingPickup: number;
+	pickupSelected: number;
+}): Promise<void> {
+	const { totalOrders, totalRevenueCents, awaitingPickup, pickupSelected } =
+		params;
+
+	if (totalOrders === 0) {
+		await sendDiscordWebhook({
+			embeds: [
+				{
+					title: "📊 Daily Order Summary",
+					description: "No new paid orders today.",
+					color: COLORS.INFO,
+					timestamp: new Date().toISOString(),
+				},
+			],
+		});
+		return;
+	}
+
+	const revenue = `$${(totalRevenueCents / 100).toFixed(2)}`;
+
+	await sendDiscordWebhook({
+		embeds: [
+			{
+				title: "📊 Daily Order Summary",
+				description: `**${totalOrders}** order${totalOrders !== 1 ? "s" : ""} paid today — **${revenue}** total revenue.`,
+				color: COLORS.INFO,
+				fields: [
+					{
+						name: "Awaiting Pickup Selection",
+						value: String(awaitingPickup),
+						inline: true,
+					},
+					{
+						name: "Pickup Selected",
+						value: String(pickupSelected),
+						inline: true,
+					},
+				],
+				timestamp: new Date().toISOString(),
+			},
+		],
+	});
+}
+
+/**
  * Notify admins that a customer selected a pickup timeslot.
  * The admin needs to prepare the order for collection.
  */

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -219,6 +219,70 @@ export async function sendTimeslotsAvailableEmail(params: {
 	});
 }
 
+/**
+ * Send a notification email when an admin updates a timeslot's date/time.
+ * Each affected customer receives one email per order in that timeslot,
+ * showing the diff of what changed and their order summary.
+ */
+export async function sendTimeslotChangedEmail(params: {
+	to: string;
+	customerName: string;
+	orderNumber: string;
+	files: OrderFile[];
+	pricing: PricingInfo | undefined;
+	previous: TimeslotInfo;
+	updated: TimeslotInfo;
+}): Promise<void> {
+	const { to, customerName, orderNumber, files, pricing, previous, updated } =
+		params;
+
+	const formatDate = (d: string | undefined) =>
+		d
+			? new Date(d).toLocaleDateString("en-NZ", {
+					weekday: "long",
+					day: "numeric",
+					month: "long",
+					year: "numeric",
+				})
+			: "TBD";
+
+	const previousDate = formatDate(previous.date);
+	const newDate = formatDate(updated.date);
+	const dateChanged = previousDate !== newDate;
+	const startTimeChanged = previous.startTime !== updated.startTime;
+	const endTimeChanged = previous.endTime !== updated.endTime;
+
+	const common = await buildCommonLocals(customerName);
+
+	const html = renderTemplate("timeslotChanged", {
+		...common,
+		orderNumber,
+		files: formatFilesForTemplate(files),
+		...formatPricingForTemplate(pricing),
+		// Diff flags
+		dateChanged,
+		previousDate,
+		newDate,
+		startTimeChanged,
+		previousStartTime: previous.startTime,
+		newStartTime: updated.startTime,
+		endTimeChanged,
+		previousEndTime: previous.endTime,
+		newEndTime: updated.endTime,
+		// Updated pickup details
+		pickupDate: newDate,
+		pickupTime: `${updated.startTime} – ${updated.endTime}`,
+		pickupLabel: updated.label,
+	});
+
+	await getTransporter().sendMail({
+		from: fromAddress(),
+		to,
+		subject: `Pickup Time Updated — ${orderNumber}`,
+		html,
+	});
+}
+
 // ── Helpers ──────────────────────────────────────────────────────────────
 
 function formatCents(cents: number | undefined | null): string {

--- a/lib/templates/timeslotChanged.pug
+++ b/lib/templates/timeslotChanged.pug
@@ -1,0 +1,71 @@
+include _mixins
+
+doctype html
+html
+  head
+    meta(charset="utf-8")
+    meta(name="viewport" content="width=device-width, initial-scale=1.0")
+    include _styles
+  body
+    .container
+      .header
+        h1 Pickup Time Updated
+        p Order ##{orderNumber}
+
+      .content
+        p Hi #{customerName},
+
+        p We wanted to let you know that the pickup timeslot for your order has been updated. Please review the changes below:
+
+        .section
+          .info-box
+            h3 📅 What Changed
+            if dateChanged
+              p
+                strong Previous Date:&nbsp;
+                | #{previousDate}
+              p
+                strong New Date:&nbsp;
+                | #{newDate}
+            if startTimeChanged
+              p
+                strong Previous Start Time:&nbsp;
+                | #{previousStartTime}
+              p
+                strong New Start Time:&nbsp;
+                | #{newStartTime}
+            if endTimeChanged
+              p
+                strong Previous End Time:&nbsp;
+                | #{previousEndTime}
+              p
+                strong New End Time:&nbsp;
+                | #{newEndTime}
+
+        .section
+          .pickup-box
+            h3 📍 Updated Pickup Details
+            p
+              strong Date:&nbsp;
+              | #{pickupDate}
+            p
+              strong Time:&nbsp;
+              | #{pickupTime}
+            if pickupLabel
+              p
+                strong Slot:&nbsp;
+                | #{pickupLabel}
+
+        +fileList(files)
+
+        +pricingTable(subtotal, tax, total)
+
+        p If this new time doesn't work for you, please visit your orders page to select a different pickup slot.
+        p
+          a.btn(href=ordersUrl) View My Orders
+
+        p If you have any questions, please contact us:
+        +contactAndFooter(contactEmail, contactPhone)
+
+      .footer
+        p Primal Printing — Thank you for your order!

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.4.12",
+		"@biomejs/biome": "~2.4.12",
 		"@types/node": "25.6.0",
 		"@types/react": "19.2.14",
 		"@types/react-dom": "19.2.3",

--- a/pages/my-orders.tsx
+++ b/pages/my-orders.tsx
@@ -170,6 +170,18 @@ const MyOrders: NextPage<PageProps> = ({ contactInfo }) => {
 				</Button>
 			);
 		}
+		if (order.status === OrderStatus.AWAITING_PICKUP) {
+			return (
+				<Button
+					size="sm"
+					colorScheme="orange"
+					variant="outline"
+					onClick={() => router.push(`/order?pickupFor=${order.id}`)}
+				>
+					Change Pickup
+				</Button>
+			);
+		}
 		return null;
 	};
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,7 +128,7 @@ importers:
         version: 4.3.6
     devDependencies:
       '@biomejs/biome':
-        specifier: 2.4.12
+        specifier: ~2.4.12
         version: 2.4.12
       '@types/node':
         specifier: 25.6.0


### PR DESCRIPTION
## Summary

### Timeslot Change Notifications
- **Payload afterChange hook** on Timeslots collection detects when an admin updates `date`, `startTime`, or `endTime`
- Queries all orders linked to the changed timeslot and emails each customer
- **New email template** (`timeslotChanged.pug`) shows the diff (what changed) + order summary + updated pickup details
- **New email function** `sendTimeslotChangedEmail()` in `lib/email.ts`
- Runs fire-and-forget so the admin UI isn't blocked

### Timeslot Re-selection
- `select-timeslot` API route now accepts `AWAITING_PICKUP` orders (not just `PAID`)
- Re-selection updates the timeslot without changing order status
- **"Change Pickup" button** added to My Orders page and Order Container for `AWAITING_PICKUP` orders
- `pickupFor` query param works for both `PAID` and `AWAITING_PICKUP` orders

### Daily Order Summary (Discord)
- **New cron endpoint** `/api/cron/daily-order-summary` posts a Discord rollup of paid orders for the day
- Shows total orders, revenue, and pickup selection status
- Runs daily at 18:00 UTC via GitHub Actions
- Registered in the cron workflow matrix with manual dispatch support

## Files Changed
- `collections/Timeslots.ts` — afterChange hook
- `lib/email.ts` — `sendTimeslotChangedEmail()`
- `lib/templates/timeslotChanged.pug` — new email template
- `app/api/shop/[orderId]/select-timeslot/route.ts` — AWAITING_PICKUP support
- `pages/my-orders.tsx` — Change Pickup button
- `components/ordercontainer/OrderContainer.tsx` — re-selection flow
- `lib/discord.ts` — `notifyDailyOrderSummary()`
- `app/api/cron/daily-order-summary/route.ts` — new cron endpoint
- `.github/workflows/cron.yml` — registered new cron job