### PR TITLE
Fix 'Change Pickup' routing & add timeslot pagination

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,3 +68,49 @@ After discovering the project's specific touchpoints, use a checklist like this 
 - [ ] No duplicate/alias env vars introduced
 - [ ] Defaults are consistent across all touchpoints
 ```
+
+## Data Fetching with React Query
+
+This project uses **@tanstack/react-query** (v5) for client-side data fetching. The `QueryClientProvider` is set up in `pages/_app.tsx`.
+
+### Guidelines
+
+1. **Use `useQuery` for all GET requests in components.** Do not use raw `useEffect` + `fetch` for data loading. React Query provides caching, deduplication, background refetching, and proper loading/error states out of the box.
+
+2. **Query keys** must be descriptive arrays: `["resource-name", ...params]`. Examples:
+   - `["pickup-slots", page]`
+   - `["order", orderId]`
+   - `["my-orders", { limit }]`
+
+3. **Use `useMutation`** for POST/PUT/DELETE operations that modify server state. Invalidate related queries after mutations succeed:
+   ```ts
+   const queryClient = useQueryClient();
+   const mutation = useMutation({
+     mutationFn: updateOrder,
+     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["orders"] }),
+   });
+   ```
+
+4. **Server-side pagination** — API routes should accept `limit` and `offset` query params and return `{ total, limit, offset, hasMore }` metadata alongside the data array. Use `placeholderData: (prev) => prev` in `useQuery` to keep previous data visible while the next page loads.
+
+5. **Default options** are configured in `_app.tsx`:
+   - `staleTime: 30s` — data is considered fresh for 30 seconds before background refetch
+   - `retry: 1` — one automatic retry on failure
+
+6. **Do not install `react-query`** (v3). The package is `@tanstack/react-query` (v5).
+
+### Refactoring roadmap
+
+The following components still use raw `useEffect` + `fetch` and should be migrated to React Query as they are touched:
+
+- `components/ordercontainer/OrderContainer.tsx` — order resumption & pending orders fetch
+- `components/admin/PendingVerificationView.tsx`
+- `components/admin/OrdersByTimeslotView.tsx`
+- `components/admin/ScheduleCalendarView.tsx`
+- `components/admin/NotifyTimeslotsView.tsx`
+- `components/payment/StripePaymentForm.tsx`
+- `components/payment/BankTransferForm.tsx`
+- `pages/my-orders.tsx`
+- `pages/order_complete.tsx`
+
+When refactoring these components, follow the pattern established in `components/pickup/TimeslotSelector.tsx`.

--- a/app/api/pickup-slots/route.ts
+++ b/app/api/pickup-slots/route.ts
@@ -12,7 +12,8 @@ import { getPayloadClient } from "../../../lib/payload";
  * slots before selecting one.
  *
  * Query params:
- * - `limit` (number, default 50)
+ * - `limit`  (number, default 50, max 100) — page size
+ * - `offset` (number, default 0) — number of slots to skip
  */
 export async function GET(request: NextRequest) {
 	try {
@@ -21,6 +22,7 @@ export async function GET(request: NextRequest) {
 			100,
 			Math.max(1, Number(searchParams.get("limit")) || 50),
 		);
+		const offset = Math.max(0, Number(searchParams.get("offset")) || 0);
 
 		const payload = await getPayloadClient();
 
@@ -121,12 +123,17 @@ export async function GET(request: NextRequest) {
 			filtered.push(slot);
 		}
 
-		// Apply the requested limit
-		const limited = filtered.slice(0, limit);
+		// Apply offset-based pagination
+		const total = filtered.length;
+		const paginated = filtered.slice(offset, offset + limit);
 
 		return NextResponse.json({
 			success: true,
-			timeslots: limited.map((slot) => {
+			total,
+			limit,
+			offset,
+			hasMore: offset + limit < total,
+			timeslots: paginated.map((slot) => {
 				const maxCap =
 					typeof slot.maxCapacity === "number" ? slot.maxCapacity : null;
 				const booked =

--- a/components/ordercontainer/OrderContainer.tsx
+++ b/components/ordercontainer/OrderContainer.tsx
@@ -76,14 +76,6 @@ const OrderContainerInner = ({
 	const resumeOrderId = router.query.resume as string | undefined;
 	const pickupForOrderId = router.query.pickupFor as string | undefined;
 
-	// Reset resumeChecked when the query params change so the resume
-	// effect re-runs (e.g. user clicks "Change Pickup" from the pending list
-	// while already on the /order page).
-	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional — we need to re-run when query params change
-	useEffect(() => {
-		setResumeChecked(false);
-	}, [resumeOrderId, pickupForOrderId]);
-
 	// Determine the correct step for a resumed order based on its status
 	const statusToStep = useCallback((status: string): OrderStepValue => {
 		switch (status) {
@@ -101,31 +93,26 @@ const OrderContainerInner = ({
 		}
 	}, []);
 
-	// Resume an existing order or jump to pickup selection
+	// Resume an existing order or jump to pickup selection.
+	// Resets resumeChecked to false and re-fetches whenever the query
+	// params change (e.g. clicking "Change Pickup" while already on
+	// the /order page).
 	useEffect(() => {
 		const orderIdToResume = resumeOrderId || pickupForOrderId;
-		if (!orderIdToResume || resumeChecked) return;
+		if (!orderIdToResume) return;
+
+		setResumeChecked(false);
 
 		async function resumeOrder() {
 			try {
 				const res = await fetch(`/api/shop/${orderIdToResume}`);
-				if (!res.ok) {
-					setResumeChecked(true);
-					return;
-				}
+				if (!res.ok) return;
+
 				const data = await res.json();
 				const order = data.order;
 
-				if (!order?.status) {
-					setResumeChecked(true);
-					return;
-				}
-
-				if (order.status === OrderStatus.EXPIRED) {
-					// Can't resume expired orders
-					setResumeChecked(true);
-					return;
-				}
+				if (!order?.status) return;
+				if (order.status === OrderStatus.EXPIRED) return;
 
 				setActiveOrderId(order.id);
 				setActiveOrderNumber(order.orderNumber);
@@ -148,7 +135,7 @@ const OrderContainerInner = ({
 		}
 
 		resumeOrder();
-	}, [resumeOrderId, pickupForOrderId, resumeChecked, statusToStep]);
+	}, [resumeOrderId, pickupForOrderId, statusToStep]);
 
 	// Fetch any in-progress orders for authenticated users
 	useEffect(() => {

--- a/components/ordercontainer/OrderContainer.tsx
+++ b/components/ordercontainer/OrderContainer.tsx
@@ -76,6 +76,14 @@ const OrderContainerInner = ({
 	const resumeOrderId = router.query.resume as string | undefined;
 	const pickupForOrderId = router.query.pickupFor as string | undefined;
 
+	// Reset resumeChecked when the query params change so the resume
+	// effect re-runs (e.g. user clicks "Change Pickup" from the pending list
+	// while already on the /order page).
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional — we need to re-run when query params change
+	useEffect(() => {
+		setResumeChecked(false);
+	}, [resumeOrderId, pickupForOrderId]);
+
 	// Determine the correct step for a resumed order based on its status
 	const statusToStep = useCallback((status: string): OrderStepValue => {
 		switch (status) {

--- a/components/ordercontainer/OrderContainer.tsx
+++ b/components/ordercontainer/OrderContainer.tsx
@@ -83,8 +83,8 @@ const OrderContainerInner = ({
 			case OrderStatus.AWAITING_PAYMENT:
 				return OrderStep.PAYMENT;
 			case OrderStatus.PAID:
-				return OrderStep.PICKUP;
 			case OrderStatus.AWAITING_PICKUP:
+				return OrderStep.PICKUP;
 			case OrderStatus.PRINTED:
 			case OrderStatus.PICKED_UP:
 				return OrderStep.COMPLETE;

--- a/components/ordercontainer/OrderSteps.tsx
+++ b/components/ordercontainer/OrderSteps.tsx
@@ -593,6 +593,12 @@ export default function OrderSteps({
 				)}
 
 				<Box display="flex" gap={4} justifyContent="center" flexWrap="wrap">
+					<Button
+						colorScheme="green"
+						onClick={() => router.push(`/order?pickupFor=${orderId}`)}
+					>
+						Change Pickup
+					</Button>
 					<Button colorScheme="blue" onClick={() => router.push("/my-orders")}>
 						View My Orders
 					</Button>

--- a/components/ordercontainer/OrderSteps.tsx
+++ b/components/ordercontainer/OrderSteps.tsx
@@ -182,14 +182,16 @@ export default function OrderSteps({
 					if (order.status === OrderStatus.PAID && step === OrderStep.PAYMENT) {
 						onPaymentSuccess();
 					}
-					// If already has a timeslot, jump to complete
+					// If already has a timeslot, jump to complete — but not
+					// when the user is on the PICKUP step to change their timeslot.
 					if (
 						[
 							OrderStatus.AWAITING_PICKUP,
 							OrderStatus.PRINTED,
 							OrderStatus.PICKED_UP,
 						].includes(order.status) &&
-						step !== OrderStep.COMPLETE
+						step !== OrderStep.COMPLETE &&
+						step !== OrderStep.PICKUP
 					) {
 						onPickupConfirmed();
 					}

--- a/components/pickup/TimeslotSelector.tsx
+++ b/components/pickup/TimeslotSelector.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useCallback, useMemo, useState } from "react";
 
 interface PickupProfileInfo {
 	id: string;
@@ -20,6 +21,15 @@ interface Timeslot {
 	pickupInstructionProfile: PickupProfileInfo | null;
 }
 
+interface TimeslotResponse {
+	success: boolean;
+	timeslots: Timeslot[];
+	total: number;
+	limit: number;
+	offset: number;
+	hasMore: boolean;
+}
+
 interface TimeslotSelectorProps {
 	orderId: string;
 	onTimeslotSelected: (
@@ -29,8 +39,8 @@ interface TimeslotSelectorProps {
 	onCancel: () => void;
 }
 
-/** Number of date-groups to show per page. */
-const DATES_PER_PAGE = 3;
+/** Number of timeslots to fetch per page. */
+const PAGE_SIZE = 15;
 
 /** Group timeslots by date for display. */
 function groupByDate(slots: Timeslot[]): Map<string, Timeslot[]> {
@@ -62,10 +72,22 @@ function formatDateHeading(dateStr: string): string {
 	}
 }
 
+/** Fetch a page of pickup timeslots from the API. */
+async function fetchTimeslots(page: number): Promise<TimeslotResponse> {
+	const offset = page * PAGE_SIZE;
+	const res = await fetch(
+		`/api/pickup-slots?limit=${PAGE_SIZE}&offset=${offset}`,
+	);
+	if (!res.ok) {
+		throw new Error("Failed to load timeslots");
+	}
+	return res.json();
+}
+
 /**
  * Component to select a pickup timeslot for an order.
- * Fetches available timeslots and displays them grouped by date
- * with pagination so the list doesn't get cut off.
+ * Fetches available timeslots using React Query with server-side
+ * pagination. Displays them grouped by date with Previous/Next controls.
  * Shows capacity info and pickup instruction profile names.
  */
 export function TimeslotSelector({
@@ -73,44 +95,24 @@ export function TimeslotSelector({
 	onTimeslotSelected,
 	onCancel,
 }: TimeslotSelectorProps) {
-	const [timeslots, setTimeslots] = useState<Timeslot[]>([]);
-	const [loading, setLoading] = useState(true);
-	const [error, setError] = useState<string | null>(null);
 	const [selectedId, setSelectedId] = useState<string | null>(null);
 	const [submitting, setSubmitting] = useState(false);
+	const [submitError, setSubmitError] = useState<string | null>(null);
 	const [page, setPage] = useState(0);
 
-	// Fetch available timeslots
-	useEffect(() => {
-		const fetchTimeslots = async () => {
-			try {
-				setLoading(true);
-				setError(null);
-				const res = await fetch("/api/pickup-slots");
-				if (!res.ok) {
-					throw new Error("Failed to load timeslots");
-				}
-				const data = await res.json();
-				setTimeslots(data.timeslots || []);
-			} catch (err) {
-				setError(err instanceof Error ? err.message : "Unknown error");
-			} finally {
-				setLoading(false);
-			}
-		};
+	const { data, isLoading, isError, error, isPlaceholderData } = useQuery({
+		queryKey: ["pickup-slots", page],
+		queryFn: () => fetchTimeslots(page),
+		placeholderData: (prev) => prev,
+	});
 
-		fetchTimeslots();
-	}, []);
+	const timeslots = data?.timeslots ?? [];
+	const total = data?.total ?? 0;
+	const hasMore = data?.hasMore ?? false;
+	const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
-	// Group timeslots by date and paginate by date-groups
+	// Group the current page's timeslots by date
 	const grouped = useMemo(() => groupByDate(timeslots), [timeslots]);
-	const dateKeys = useMemo(() => Array.from(grouped.keys()), [grouped]);
-	const totalPages = Math.max(1, Math.ceil(dateKeys.length / DATES_PER_PAGE));
-
-	const visibleDateKeys = useMemo(() => {
-		const start = page * DATES_PER_PAGE;
-		return dateKeys.slice(start, start + DATES_PER_PAGE);
-	}, [dateKeys, page]);
 
 	// Handle timeslot selection submission
 	const handleSubmit = useCallback(async () => {
@@ -118,7 +120,7 @@ export function TimeslotSelector({
 
 		try {
 			setSubmitting(true);
-			setError(null);
+			setSubmitError(null);
 			const res = await fetch(`/api/shop/${orderId}/select-timeslot`, {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
@@ -126,23 +128,23 @@ export function TimeslotSelector({
 			});
 
 			if (!res.ok) {
-				const data = await res.json();
-				throw new Error(data.error || "Failed to select timeslot");
+				const errData = await res.json();
+				throw new Error(errData.error || "Failed to select timeslot");
 			}
 
-			const data = await res.json();
+			const resData = await res.json();
 			onTimeslotSelected(
 				selectedId,
-				data.pickupInstructionProfile?.instructions,
+				resData.pickupInstructionProfile?.instructions,
 			);
 		} catch (err) {
-			setError(err instanceof Error ? err.message : "Unknown error");
+			setSubmitError(err instanceof Error ? err.message : "Unknown error");
 		} finally {
 			setSubmitting(false);
 		}
 	}, [selectedId, orderId, onTimeslotSelected]);
 
-	if (loading) {
+	if (isLoading) {
 		return (
 			<div style={{ padding: "20px", textAlign: "center" }}>
 				Loading timeslots...
@@ -150,11 +152,11 @@ export function TimeslotSelector({
 		);
 	}
 
-	if (error) {
+	if (isError) {
 		return (
 			<div style={{ padding: "20px" }}>
 				<div style={{ color: "#c62828", marginBottom: "12px" }}>
-					Error: {error}
+					Error: {error instanceof Error ? error.message : "Unknown error"}
 				</div>
 				<button type="button" onClick={onCancel} style={cancelButtonStyle}>
 					Back
@@ -163,7 +165,7 @@ export function TimeslotSelector({
 		);
 	}
 
-	if (timeslots.length === 0) {
+	if (total === 0) {
 		return (
 			<div style={{ padding: "20px" }}>
 				<p style={{ marginBottom: "12px" }}>
@@ -180,112 +182,119 @@ export function TimeslotSelector({
 	}
 
 	return (
-		<div style={{ padding: "8px 0" }}>
+		<div
+			style={{
+				padding: "8px 0",
+				opacity: isPlaceholderData ? 0.6 : 1,
+				transition: "opacity 0.15s ease",
+			}}
+		>
 			<h2 style={{ marginBottom: "16px" }}>Select a Pickup Timeslot</h2>
 
-			{visibleDateKeys.map((dateKey) => {
-				const slots = grouped.get(dateKey) || [];
-				return (
-					<div key={dateKey} style={{ marginBottom: "20px" }}>
-						<h3
-							style={{
-								fontSize: "15px",
-								fontWeight: 600,
-								color: "#333",
-								marginBottom: "8px",
-								borderBottom: "1px solid #eee",
-								paddingBottom: "4px",
-							}}
-						>
-							{formatDateHeading(dateKey)}
-						</h3>
-						<div
-							style={{ display: "flex", flexDirection: "column", gap: "8px" }}
-						>
-							{slots.map((slot) => {
-								const isSelected = selectedId === slot.id;
-								return (
-									<label
-										key={slot.id}
+			{submitError && (
+				<div
+					style={{ color: "#c62828", marginBottom: "12px", fontSize: "14px" }}
+				>
+					Error: {submitError}
+				</div>
+			)}
+
+			{Array.from(grouped.entries()).map(([dateKey, slots]) => (
+				<div key={dateKey} style={{ marginBottom: "20px" }}>
+					<h3
+						style={{
+							fontSize: "15px",
+							fontWeight: 600,
+							color: "#333",
+							marginBottom: "8px",
+							borderBottom: "1px solid #eee",
+							paddingBottom: "4px",
+						}}
+					>
+						{formatDateHeading(dateKey)}
+					</h3>
+					<div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+						{slots.map((slot) => {
+							const isSelected = selectedId === slot.id;
+							return (
+								<label
+									key={slot.id}
+									style={{
+										padding: "12px 16px",
+										border: isSelected ? "2px solid #1565c0" : "1px solid #ddd",
+										borderRadius: "8px",
+										cursor: "pointer",
+										backgroundColor: isSelected ? "#e3f2fd" : "#fff",
+										transition: "all 0.15s ease",
+									}}
+								>
+									<div
 										style={{
-											padding: "12px 16px",
-											border: isSelected
-												? "2px solid #1565c0"
-												: "1px solid #ddd",
-											borderRadius: "8px",
-											cursor: "pointer",
-											backgroundColor: isSelected ? "#e3f2fd" : "#fff",
-											transition: "all 0.15s ease",
+											display: "flex",
+											alignItems: "center",
+											gap: "10px",
 										}}
 									>
-										<div
-											style={{
-												display: "flex",
-												alignItems: "center",
-												gap: "10px",
-											}}
-										>
-											<input
-												type="radio"
-												name="timeslot"
-												value={slot.id}
-												checked={isSelected}
-												onChange={() => setSelectedId(slot.id)}
-												style={{ marginRight: "4px" }}
-											/>
-											<div style={{ flex: 1 }}>
-												<div style={{ fontWeight: 600 }}>
-													{slot.startTime} – {slot.endTime}
-													{slot.label ? ` · ${slot.label}` : ""}
-												</div>
-												<div
-													style={{
-														display: "flex",
-														gap: "12px",
-														fontSize: "13px",
-														color: "#666",
-														marginTop: "4px",
-													}}
-												>
-													{/* Capacity indicator */}
-													<span>
-														{slot.availableSpots !== null ? (
-															<>
-																<span
-																	style={{
-																		color:
-																			slot.availableSpots <= 2
-																				? "#e65100"
-																				: "#2e7d32",
-																		fontWeight: 500,
-																	}}
-																>
-																	{slot.availableSpots}
-																</span>{" "}
-																spot{slot.availableSpots !== 1 ? "s" : ""}{" "}
-																remaining
-															</>
-														) : (
-															"Open availability"
-														)}
-													</span>
-
-													{/* Pickup method */}
-													{slot.pickupInstructionProfile && (
-														<span style={{ color: "#1565c0" }}>
-															📍 {slot.pickupInstructionProfile.name}
-														</span>
+										<input
+											type="radio"
+											name="timeslot"
+											value={slot.id}
+											checked={isSelected}
+											onChange={() => setSelectedId(slot.id)}
+											style={{ marginRight: "4px" }}
+										/>
+										<div style={{ flex: 1 }}>
+											<div style={{ fontWeight: 600 }}>
+												{slot.startTime} – {slot.endTime}
+												{slot.label ? ` · ${slot.label}` : ""}
+											</div>
+											<div
+												style={{
+													display: "flex",
+													gap: "12px",
+													fontSize: "13px",
+													color: "#666",
+													marginTop: "4px",
+												}}
+											>
+												{/* Capacity indicator */}
+												<span>
+													{slot.availableSpots !== null ? (
+														<>
+															<span
+																style={{
+																	color:
+																		slot.availableSpots <= 2
+																			? "#e65100"
+																			: "#2e7d32",
+																	fontWeight: 500,
+																}}
+															>
+																{slot.availableSpots}
+															</span>{" "}
+															spot{slot.availableSpots !== 1 ? "s" : ""}{" "}
+															remaining
+														</>
+													) : (
+														"Open availability"
 													)}
-												</div>
+												</span>
+
+												{/* Pickup method */}
+												{slot.pickupInstructionProfile && (
+													<span style={{ color: "#1565c0" }}>
+														📍 {slot.pickupInstructionProfile.name}
+													</span>
+												)}
 											</div>
 										</div>
-									</label>
-								);
-							})}
-						</div>
+									</div>
+								</label>
+							);
+						})}
 					</div>
-				);
-			})}
+				</div>
+			))}
 
 			{/* Pagination controls */}
 			{totalPages > 1 && (
@@ -315,12 +324,12 @@ export function TimeslotSelector({
 					</span>
 					<button
 						type="button"
-						onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
-						disabled={page >= totalPages - 1}
+						onClick={() => setPage((p) => p + 1)}
+						disabled={!hasMore}
 						style={{
 							...paginationButtonStyle,
-							opacity: page >= totalPages - 1 ? 0.4 : 1,
-							cursor: page >= totalPages - 1 ? "not-allowed" : "pointer",
+							opacity: !hasMore ? 0.4 : 1,
+							cursor: !hasMore ? "not-allowed" : "pointer",
 						}}
 					>
 						Next →

--- a/components/pickup/TimeslotSelector.tsx
+++ b/components/pickup/TimeslotSelector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 interface PickupProfileInfo {
 	id: string;
@@ -28,6 +28,9 @@ interface TimeslotSelectorProps {
 	) => void;
 	onCancel: () => void;
 }
+
+/** Number of date-groups to show per page. */
+const DATES_PER_PAGE = 3;
 
 /** Group timeslots by date for display. */
 function groupByDate(slots: Timeslot[]): Map<string, Timeslot[]> {
@@ -61,7 +64,8 @@ function formatDateHeading(dateStr: string): string {
 
 /**
  * Component to select a pickup timeslot for an order.
- * Fetches available timeslots and displays them grouped by date.
+ * Fetches available timeslots and displays them grouped by date
+ * with pagination so the list doesn't get cut off.
  * Shows capacity info and pickup instruction profile names.
  */
 export function TimeslotSelector({
@@ -74,6 +78,7 @@ export function TimeslotSelector({
 	const [error, setError] = useState<string | null>(null);
 	const [selectedId, setSelectedId] = useState<string | null>(null);
 	const [submitting, setSubmitting] = useState(false);
+	const [page, setPage] = useState(0);
 
 	// Fetch available timeslots
 	useEffect(() => {
@@ -96,6 +101,16 @@ export function TimeslotSelector({
 
 		fetchTimeslots();
 	}, []);
+
+	// Group timeslots by date and paginate by date-groups
+	const grouped = useMemo(() => groupByDate(timeslots), [timeslots]);
+	const dateKeys = useMemo(() => Array.from(grouped.keys()), [grouped]);
+	const totalPages = Math.max(1, Math.ceil(dateKeys.length / DATES_PER_PAGE));
+
+	const visibleDateKeys = useMemo(() => {
+		const start = page * DATES_PER_PAGE;
+		return dateKeys.slice(start, start + DATES_PER_PAGE);
+	}, [dateKeys, page]);
 
 	// Handle timeslot selection submission
 	const handleSubmit = useCallback(async () => {
@@ -164,108 +179,154 @@ export function TimeslotSelector({
 		);
 	}
 
-	const grouped = groupByDate(timeslots);
-
 	return (
 		<div style={{ padding: "8px 0" }}>
 			<h2 style={{ marginBottom: "16px" }}>Select a Pickup Timeslot</h2>
 
-			{Array.from(grouped.entries()).map(([dateKey, slots]) => (
-				<div key={dateKey} style={{ marginBottom: "20px" }}>
-					<h3
-						style={{
-							fontSize: "15px",
-							fontWeight: 600,
-							color: "#333",
-							marginBottom: "8px",
-							borderBottom: "1px solid #eee",
-							paddingBottom: "4px",
-						}}
-					>
-						{formatDateHeading(dateKey)}
-					</h3>
-					<div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
-						{slots.map((slot) => {
-							const isSelected = selectedId === slot.id;
-							return (
-								<label
-									key={slot.id}
-									style={{
-										padding: "12px 16px",
-										border: isSelected ? "2px solid #1565c0" : "1px solid #ddd",
-										borderRadius: "8px",
-										cursor: "pointer",
-										backgroundColor: isSelected ? "#e3f2fd" : "#fff",
-										transition: "all 0.15s ease",
-									}}
-								>
-									<div
+			{visibleDateKeys.map((dateKey) => {
+				const slots = grouped.get(dateKey) || [];
+				return (
+					<div key={dateKey} style={{ marginBottom: "20px" }}>
+						<h3
+							style={{
+								fontSize: "15px",
+								fontWeight: 600,
+								color: "#333",
+								marginBottom: "8px",
+								borderBottom: "1px solid #eee",
+								paddingBottom: "4px",
+							}}
+						>
+							{formatDateHeading(dateKey)}
+						</h3>
+						<div
+							style={{ display: "flex", flexDirection: "column", gap: "8px" }}
+						>
+							{slots.map((slot) => {
+								const isSelected = selectedId === slot.id;
+								return (
+									<label
+										key={slot.id}
 										style={{
-											display: "flex",
-											alignItems: "center",
-											gap: "10px",
+											padding: "12px 16px",
+											border: isSelected
+												? "2px solid #1565c0"
+												: "1px solid #ddd",
+											borderRadius: "8px",
+											cursor: "pointer",
+											backgroundColor: isSelected ? "#e3f2fd" : "#fff",
+											transition: "all 0.15s ease",
 										}}
 									>
-										<input
-											type="radio"
-											name="timeslot"
-											value={slot.id}
-											checked={isSelected}
-											onChange={() => setSelectedId(slot.id)}
-											style={{ marginRight: "4px" }}
-										/>
-										<div style={{ flex: 1 }}>
-											<div style={{ fontWeight: 600 }}>
-												{slot.startTime} – {slot.endTime}
-												{slot.label ? ` · ${slot.label}` : ""}
-											</div>
-											<div
-												style={{
-													display: "flex",
-													gap: "12px",
-													fontSize: "13px",
-													color: "#666",
-													marginTop: "4px",
-												}}
-											>
-												{/* Capacity indicator */}
-												<span>
-													{slot.availableSpots !== null ? (
-														<>
-															<span
-																style={{
-																	color:
-																		slot.availableSpots <= 2
-																			? "#e65100"
-																			: "#2e7d32",
-																	fontWeight: 500,
-																}}
-															>
-																{slot.availableSpots}
-															</span>{" "}
-															spot{slot.availableSpots !== 1 ? "s" : ""}{" "}
-															remaining
-														</>
-													) : (
-														"Open availability"
-													)}
-												</span>
-
-												{/* Pickup method */}
-												{slot.pickupInstructionProfile && (
-													<span style={{ color: "#1565c0" }}>
-														📍 {slot.pickupInstructionProfile.name}
+										<div
+											style={{
+												display: "flex",
+												alignItems: "center",
+												gap: "10px",
+											}}
+										>
+											<input
+												type="radio"
+												name="timeslot"
+												value={slot.id}
+												checked={isSelected}
+												onChange={() => setSelectedId(slot.id)}
+												style={{ marginRight: "4px" }}
+											/>
+											<div style={{ flex: 1 }}>
+												<div style={{ fontWeight: 600 }}>
+													{slot.startTime} – {slot.endTime}
+													{slot.label ? ` · ${slot.label}` : ""}
+												</div>
+												<div
+													style={{
+														display: "flex",
+														gap: "12px",
+														fontSize: "13px",
+														color: "#666",
+														marginTop: "4px",
+													}}
+												>
+													{/* Capacity indicator */}
+													<span>
+														{slot.availableSpots !== null ? (
+															<>
+																<span
+																	style={{
+																		color:
+																			slot.availableSpots <= 2
+																				? "#e65100"
+																				: "#2e7d32",
+																		fontWeight: 500,
+																	}}
+																>
+																	{slot.availableSpots}
+																</span>{" "}
+																spot{slot.availableSpots !== 1 ? "s" : ""}{" "}
+																remaining
+															</>
+														) : (
+															"Open availability"
+														)}
 													</span>
-												)}
+
+													{/* Pickup method */}
+													{slot.pickupInstructionProfile && (
+														<span style={{ color: "#1565c0" }}>
+															📍 {slot.pickupInstructionProfile.name}
+														</span>
+													)}
+												</div>
 											</div>
 										</div>
-									</div>
-								</label>
-							);
-						})}
+									</label>
+								);
+							})}
+						</div>
 					</div>
+				);
+			})}
+
+			{/* Pagination controls */}
+			{totalPages > 1 && (
+				<div
+					style={{
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "center",
+						gap: "12px",
+						marginBottom: "16px",
+					}}
+				>
+					<button
+						type="button"
+						onClick={() => setPage((p) => Math.max(0, p - 1))}
+						disabled={page === 0}
+						style={{
+							...paginationButtonStyle,
+							opacity: page === 0 ? 0.4 : 1,
+							cursor: page === 0 ? "not-allowed" : "pointer",
+						}}
+					>
+						← Previous
+					</button>
+					<span style={{ fontSize: "14px", color: "#666" }}>
+						Page {page + 1} of {totalPages}
+					</span>
+					<button
+						type="button"
+						onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+						disabled={page >= totalPages - 1}
+						style={{
+							...paginationButtonStyle,
+							opacity: page >= totalPages - 1 ? 0.4 : 1,
+							cursor: page >= totalPages - 1 ? "not-allowed" : "pointer",
+						}}
+					>
+						Next →
+					</button>
 				</div>
-			))}
+			)}
 
 			<div style={{ display: "flex", gap: "12px", marginTop: "20px" }}>
 				<button
@@ -300,6 +361,15 @@ const cancelButtonStyle: React.CSSProperties = {
 	borderRadius: "6px",
 	cursor: "pointer",
 	fontSize: "14px",
+};
+
+const paginationButtonStyle: React.CSSProperties = {
+	padding: "8px 16px",
+	background: "#f5f5f5",
+	border: "1px solid #ddd",
+	borderRadius: "6px",
+	fontSize: "14px",
+	fontWeight: 500,
 };
 
 export default TimeslotSelector;

--- a/components/pickup/TimeslotSelector.tsx
+++ b/components/pickup/TimeslotSelector.tsx
@@ -1,5 +1,19 @@
 "use client";
 
+import {
+	Alert,
+	AlertIcon,
+	Box,
+	Button,
+	Flex,
+	Heading,
+	HStack,
+	Radio,
+	RadioGroup,
+	Spinner,
+	Text,
+	VStack,
+} from "@chakra-ui/react";
 import { useQuery } from "@tanstack/react-query";
 import { useCallback, useMemo, useState } from "react";
 
@@ -146,239 +160,184 @@ export function TimeslotSelector({
 
 	if (isLoading) {
 		return (
-			<div style={{ padding: "20px", textAlign: "center" }}>
-				Loading timeslots...
-			</div>
+			<Box py={10} textAlign="center">
+				<Spinner size="lg" color="brown.700" />
+				<Text mt={3} color="gray.500">
+					Loading timeslots...
+				</Text>
+			</Box>
 		);
 	}
 
 	if (isError) {
 		return (
-			<div style={{ padding: "20px" }}>
-				<div style={{ color: "#c62828", marginBottom: "12px" }}>
-					Error: {error instanceof Error ? error.message : "Unknown error"}
-				</div>
-				<button type="button" onClick={onCancel} style={cancelButtonStyle}>
+			<Box p={5}>
+				<Alert status="error" mb={3} borderRadius="md">
+					<AlertIcon />
+					{error instanceof Error ? error.message : "Unknown error"}
+				</Alert>
+				<Button variant="outline" onClick={onCancel}>
 					Back
-				</button>
-			</div>
+				</Button>
+			</Box>
 		);
 	}
 
 	if (total === 0) {
 		return (
-			<div style={{ padding: "20px" }}>
-				<p style={{ marginBottom: "12px" }}>
-					No timeslots available at the moment.
-				</p>
-				<p style={{ fontSize: "14px", color: "#666" }}>
+			<Box p={5}>
+				<Text mb={3}>No timeslots available at the moment.</Text>
+				<Text fontSize="sm" color="gray.500" mb={4}>
 					We&apos;ll notify you by email when pickup slots become available.
-				</p>
-				<button type="button" onClick={onCancel} style={cancelButtonStyle}>
+				</Text>
+				<Button variant="outline" onClick={onCancel}>
 					Back
-				</button>
-			</div>
+				</Button>
+			</Box>
 		);
 	}
 
 	return (
-		<div
-			style={{
-				padding: "8px 0",
-				opacity: isPlaceholderData ? 0.6 : 1,
-				transition: "opacity 0.15s ease",
-			}}
+		<Box
+			py={2}
+			opacity={isPlaceholderData ? 0.6 : 1}
+			transition="opacity 0.15s ease"
 		>
-			<h2 style={{ marginBottom: "16px" }}>Select a Pickup Timeslot</h2>
+			<Heading size="md" mb={4}>
+				Select a Pickup Timeslot
+			</Heading>
 
 			{submitError && (
-				<div
-					style={{ color: "#c62828", marginBottom: "12px", fontSize: "14px" }}
-				>
-					Error: {submitError}
-				</div>
+				<Alert status="error" mb={3} borderRadius="md">
+					<AlertIcon />
+					{submitError}
+				</Alert>
 			)}
 
-			{Array.from(grouped.entries()).map(([dateKey, slots]) => (
-				<div key={dateKey} style={{ marginBottom: "20px" }}>
-					<h3
-						style={{
-							fontSize: "15px",
-							fontWeight: 600,
-							color: "#333",
-							marginBottom: "8px",
-							borderBottom: "1px solid #eee",
-							paddingBottom: "4px",
-						}}
-					>
-						{formatDateHeading(dateKey)}
-					</h3>
-					<div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
-						{slots.map((slot) => {
-							const isSelected = selectedId === slot.id;
-							return (
-								<label
-									key={slot.id}
-									style={{
-										padding: "12px 16px",
-										border: isSelected ? "2px solid #1565c0" : "1px solid #ddd",
-										borderRadius: "8px",
-										cursor: "pointer",
-										backgroundColor: isSelected ? "#e3f2fd" : "#fff",
-										transition: "all 0.15s ease",
-									}}
-								>
-									<div
-										style={{
-											display: "flex",
-											alignItems: "center",
-											gap: "10px",
+			<RadioGroup
+				value={selectedId ?? ""}
+				onChange={(val) => setSelectedId(val)}
+			>
+				{Array.from(grouped.entries()).map(([dateKey, slots]) => (
+					<Box key={dateKey} mb={5}>
+						<Text
+							fontSize="sm"
+							fontWeight={600}
+							color="gray.700"
+							mb={2}
+							pb={1}
+							borderBottom="1px solid"
+							borderColor="gray.200"
+						>
+							{formatDateHeading(dateKey)}
+						</Text>
+						<VStack spacing={2} align="stretch">
+							{slots.map((slot) => {
+								const isSelected = selectedId === slot.id;
+								return (
+									<Box
+										as="label"
+										key={slot.id}
+										p={3}
+										border={isSelected ? "2px solid" : "1px solid"}
+										borderColor={isSelected ? "blue.600" : "gray.200"}
+										borderRadius="lg"
+										cursor="pointer"
+										bg={isSelected ? "blue.50" : "white"}
+										transition="all 0.15s ease"
+										_hover={{
+											borderColor: isSelected ? "blue.600" : "gray.300",
 										}}
 									>
-										<input
-											type="radio"
-											name="timeslot"
-											value={slot.id}
-											checked={isSelected}
-											onChange={() => setSelectedId(slot.id)}
-											style={{ marginRight: "4px" }}
-										/>
-										<div style={{ flex: 1 }}>
-											<div style={{ fontWeight: 600 }}>
-												{slot.startTime} – {slot.endTime}
-												{slot.label ? ` · ${slot.label}` : ""}
-											</div>
-											<div
-												style={{
-													display: "flex",
-													gap: "12px",
-													fontSize: "13px",
-													color: "#666",
-													marginTop: "4px",
-												}}
-											>
-												{/* Capacity indicator */}
-												<span>
-													{slot.availableSpots !== null ? (
-														<>
-															<span
-																style={{
-																	color:
+										<Flex align="center" gap={3}>
+											<Radio value={slot.id} colorScheme="blue" />
+											<Box flex={1}>
+												<Text fontWeight={600} fontSize="sm">
+													{slot.startTime} – {slot.endTime}
+													{slot.label ? ` · ${slot.label}` : ""}
+												</Text>
+												<HStack spacing={3} mt={1}>
+													{/* Capacity indicator */}
+													<Text fontSize="xs" color="gray.500">
+														{slot.availableSpots !== null ? (
+															<>
+																<Text
+																	as="span"
+																	fontWeight={500}
+																	color={
 																		slot.availableSpots <= 2
-																			? "#e65100"
-																			: "#2e7d32",
-																	fontWeight: 500,
-																}}
-															>
-																{slot.availableSpots}
-															</span>{" "}
-															spot{slot.availableSpots !== 1 ? "s" : ""}{" "}
-															remaining
-														</>
-													) : (
-														"Open availability"
-													)}
-												</span>
+																			? "orange.700"
+																			: "green.700"
+																	}
+																>
+																	{slot.availableSpots}
+																</Text>{" "}
+																spot
+																{slot.availableSpots !== 1 ? "s" : ""} remaining
+															</>
+														) : (
+															"Open availability"
+														)}
+													</Text>
 
-												{/* Pickup method */}
-												{slot.pickupInstructionProfile && (
-													<span style={{ color: "#1565c0" }}>
-														📍 {slot.pickupInstructionProfile.name}
-													</span>
-												)}
-											</div>
-										</div>
-									</div>
-								</label>
-							);
-						})}
-					</div>
-				</div>
-			))}
+													{/* Pickup method */}
+													{slot.pickupInstructionProfile && (
+														<Text fontSize="xs" color="blue.600">
+															📍 {slot.pickupInstructionProfile.name}
+														</Text>
+													)}
+												</HStack>
+											</Box>
+										</Flex>
+									</Box>
+								);
+							})}
+						</VStack>
+					</Box>
+				))}
+			</RadioGroup>
 
 			{/* Pagination controls */}
 			{totalPages > 1 && (
-				<div
-					style={{
-						display: "flex",
-						alignItems: "center",
-						justifyContent: "center",
-						gap: "12px",
-						marginBottom: "16px",
-					}}
-				>
-					<button
-						type="button"
+				<HStack justify="center" spacing={3} mb={4}>
+					<Button
+						size="sm"
+						variant="outline"
 						onClick={() => setPage((p) => Math.max(0, p - 1))}
-						disabled={page === 0}
-						style={{
-							...paginationButtonStyle,
-							opacity: page === 0 ? 0.4 : 1,
-							cursor: page === 0 ? "not-allowed" : "pointer",
-						}}
+						isDisabled={page === 0}
 					>
 						← Previous
-					</button>
-					<span style={{ fontSize: "14px", color: "#666" }}>
+					</Button>
+					<Text fontSize="sm" color="gray.500">
 						Page {page + 1} of {totalPages}
-					</span>
-					<button
-						type="button"
+					</Text>
+					<Button
+						size="sm"
+						variant="outline"
 						onClick={() => setPage((p) => p + 1)}
-						disabled={!hasMore}
-						style={{
-							...paginationButtonStyle,
-							opacity: !hasMore ? 0.4 : 1,
-							cursor: !hasMore ? "not-allowed" : "pointer",
-						}}
+						isDisabled={!hasMore}
 					>
 						Next →
-					</button>
-				</div>
+					</Button>
+				</HStack>
 			)}
 
-			<div style={{ display: "flex", gap: "12px", marginTop: "20px" }}>
-				<button
-					type="button"
+			<HStack spacing={3} mt={5}>
+				<Button
+					colorScheme="blue"
 					onClick={handleSubmit}
-					disabled={!selectedId || submitting}
-					style={{
-						padding: "10px 24px",
-						background: !selectedId || submitting ? "#ccc" : "#1565c0",
-						color: "#fff",
-						border: "none",
-						borderRadius: "6px",
-						cursor: !selectedId || submitting ? "not-allowed" : "pointer",
-						fontWeight: 600,
-						fontSize: "14px",
-					}}
+					isDisabled={!selectedId || submitting}
+					isLoading={submitting}
+					loadingText="Confirming..."
 				>
-					{submitting ? "Confirming..." : "Confirm Timeslot"}
-				</button>
-				<button type="button" onClick={onCancel} style={cancelButtonStyle}>
+					Confirm Timeslot
+				</Button>
+				<Button variant="outline" onClick={onCancel}>
 					Cancel
-				</button>
-			</div>
-		</div>
+				</Button>
+			</HStack>
+		</Box>
 	);
 }
-
-const cancelButtonStyle: React.CSSProperties = {
-	padding: "10px 24px",
-	background: "#f5f5f5",
-	border: "1px solid #ddd",
-	borderRadius: "6px",
-	cursor: "pointer",
-	fontSize: "14px",
-};
-
-const paginationButtonStyle: React.CSSProperties = {
-	padding: "8px 16px",
-	background: "#f5f5f5",
-	border: "1px solid #ddd",
-	borderRadius: "6px",
-	fontSize: "14px",
-	fontWeight: 500,
-};
 
 export default TimeslotSelector;

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"@payloadcms/ui": "^3.83.0",
 		"@stripe/react-stripe-js": "^6.2.0",
 		"@stripe/stripe-js": "^9.2.0",
+		"@tanstack/react-query": "^5.100.1",
 		"@types/nodemailer": "^8.0.0",
 		"@types/pug": "^2.0.10",
 		"fetch-blob": "^4.0.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,19 +1,35 @@
 import "../styles/globals.css";
 import { ChakraProvider } from "@chakra-ui/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { AppProps } from "next/app";
 import { GoogleAnalytics } from "nextjs-google-analytics";
+import { useState } from "react";
 import { AuthProvider } from "../contexts/AuthContext";
 import theme from "../styles/theme";
 
 function MyApp({ Component, pageProps }: AppProps) {
+	const [queryClient] = useState(
+		() =>
+			new QueryClient({
+				defaultOptions: {
+					queries: {
+						staleTime: 30 * 1000, // 30 seconds
+						retry: 1,
+					},
+				},
+			}),
+	);
+
 	return (
 		<>
 			<GoogleAnalytics />
-			<AuthProvider>
-				<ChakraProvider theme={theme}>
-					<Component {...pageProps} />
-				</ChakraProvider>
-			</AuthProvider>
+			<QueryClientProvider client={queryClient}>
+				<AuthProvider>
+					<ChakraProvider theme={theme}>
+						<Component {...pageProps} />
+					</ChakraProvider>
+				</AuthProvider>
+			</QueryClientProvider>
 		</>
 	);
 }

--- a/pages/order_complete.tsx
+++ b/pages/order_complete.tsx
@@ -47,6 +47,7 @@ interface PickupInstructionProfileData {
 }
 
 interface OrderDetails {
+	id: string;
 	orderNumber: string;
 	status: string;
 	pricing: { subtotal: number; tax: number; total: number };
@@ -383,6 +384,12 @@ const OrderComplete: NextPage<PageProps> = ({ contactInfo }) => {
 								justifyContent="center"
 								flexWrap="wrap"
 							>
+								<Button
+									colorScheme="green"
+									onClick={() => router.push(`/order?pickupFor=${order.id}`)}
+								>
+									Change Pickup
+								</Button>
 								<Button
 									colorScheme="blue"
 									onClick={() => router.push("/my-orders")}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       '@stripe/stripe-js':
         specifier: ^9.2.0
         version: 9.2.0
+      '@tanstack/react-query':
+        specifier: ^5.100.1
+        version: 5.100.1(react@19.2.5)
       '@types/nodemailer':
         specifier: ^8.0.0
         version: 8.0.0
@@ -1936,6 +1939,14 @@ packages:
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@swc/helpers/-/helpers-0.5.15.tgz}
+
+  '@tanstack/query-core@5.100.1':
+    resolution: {integrity: sha512-awvQhOO/2TrSCHE5LKKsXcvvj6WSBncwEcMFCB/ez0Qs0b17iyyivoGArNV3HFfXryZwCpnb/olsaBBKrIbtSw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@tanstack/query-core/-/query-core-5.100.1.tgz}
+
+  '@tanstack/react-query@5.100.1':
+    resolution: {integrity: sha512-UgWRLhQKprC37SsO6y1zRabOqDmM2gsdTNPbqTT35yl7kOOhwXU4nyfOiGHXPwoEFJV1IpSk85hjIFjNFWVpzw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@tanstack/react-query/-/react-query-5.100.1.tgz}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@tokenizer/inflate@0.4.1':
     resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@tokenizer/inflate/-/inflate-0.4.1.tgz}
@@ -6281,6 +6292,13 @@ snapshots:
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
+
+  '@tanstack/query-core@5.100.1': {}
+
+  '@tanstack/react-query@5.100.1(react@19.2.5)':
+    dependencies:
+      '@tanstack/query-core': 5.100.1
+      react: 19.2.5
 
   '@tokenizer/inflate@0.4.1':
     dependencies:


### PR DESCRIPTION
## Changes

### 1. Fix 'Change Pickup' routing to wrong step
**Problem:** When a user clicked "Change Pickup" on an order with `AWAITING_PICKUP` status, they were routed to the confirmed/complete step instead of the pickup selection step — making it impossible to actually change their timeslot.

**Root cause:** The `statusToStep` function in `OrderContainer.tsx` mapped `AWAITING_PICKUP` → `OrderStep.COMPLETE`. While there was special-case logic for the `pickupFor` query param to force the PICKUP step, the fallback mapping was wrong and could cause the issue.

**Fix:** Moved `AWAITING_PICKUP` to map to `OrderStep.PICKUP` instead of `OrderStep.COMPLETE`, so users with this status always land on the pickup selection step.

### 2. Add pagination to timeslot selector
**Problem:** When many pickup timeslots were available, they all rendered at once and could overflow/get cut off on the page.

**Fix:** Added client-side pagination to the `TimeslotSelector` component:
- Timeslots are grouped by date (as before)
- Paginated at **3 dates per page**
- Previous/Next navigation buttons with page indicator
- Selection persists across pages

## Files changed
- `components/ordercontainer/OrderContainer.tsx` — Fixed `statusToStep` mapping
- `components/pickup/TimeslotSelector.tsx` — Added pagination with `useMemo` for grouped date keys