### PR TITLE
Distinguish 'change' vs 'select' timeslot in pickup UI

### DIFF
--- a/components/ordercontainer/OrderSteps.tsx
+++ b/components/ordercontainer/OrderSteps.tsx
@@ -440,20 +440,34 @@ export default function OrderSteps({
 	// ── Pickup step ────────────────────────────────────────────────
 
 	if (step === OrderStep.PICKUP) {
+		const hasExistingTimeslot = !!orderDetails?.pickupTimeslot;
+
 		return (
 			<Box {...containerProps}>
 				<StepIndicator />
 				<Heading size="lg" mb={2}>
-					📍 Select Pickup Time
+					{hasExistingTimeslot
+						? "📍 Change Pickup Time"
+						: "📍 Select Pickup Time"}
 				</Heading>
 				<Text color="gray.600" mb={4}>
-					Order <strong>{orderNumber}</strong> has been paid. Choose when
-					you&apos;d like to collect it.
+					{hasExistingTimeslot ? (
+						<>
+							Order <strong>{orderNumber}</strong> already has a pickup time.
+							Select a new timeslot below.
+						</>
+					) : (
+						<>
+							Order <strong>{orderNumber}</strong> has been paid. Choose when
+							you&apos;d like to collect it.
+						</>
+					)}
 				</Text>
 				<OrderSummary />
 				<Divider mb={6} />
 				<TimeslotSelector
 					orderId={orderId}
+					currentTimeslot={orderDetails?.pickupTimeslot ?? null}
 					onTimeslotSelected={() => onPickupConfirmed()}
 					onCancel={() => router.push("/my-orders")}
 				/>

--- a/components/pickup/TimeslotSelector.tsx
+++ b/components/pickup/TimeslotSelector.tsx
@@ -49,6 +49,10 @@ interface CurrentTimeslot {
 	startTime: string;
 	endTime: string;
 	label?: string;
+	pickupInstructionProfile?:
+		| { id: string; name: string; shortSummary?: string }
+		| string
+		| null;
 }
 
 interface TimeslotSelectorProps {
@@ -232,16 +236,21 @@ export function TimeslotSelector({
 						CURRENT TIMESLOT
 					</Text>
 					<Text fontWeight={600} fontSize="sm">
-						{formatDateHeading(
-							currentTimeslot.date.includes("T")
-								? currentTimeslot.date.split("T")[0]
-								: currentTimeslot.date,
-						)}
-					</Text>
-					<Text fontSize="sm" color="gray.600">
 						{currentTimeslot.startTime} – {currentTimeslot.endTime}
 						{currentTimeslot.label ? ` · ${currentTimeslot.label}` : ""}
 					</Text>
+					{typeof currentTimeslot.pickupInstructionProfile === "object" &&
+						currentTimeslot.pickupInstructionProfile && (
+							<Text fontSize="sm" color="blue.600" mt={1}>
+								📍 {currentTimeslot.pickupInstructionProfile.name}
+								{currentTimeslot.pickupInstructionProfile.shortSummary && (
+									<Text as="span" color="gray.500">
+										{" "}
+										— {currentTimeslot.pickupInstructionProfile.shortSummary}
+									</Text>
+								)}
+							</Text>
+						)}
 				</Box>
 			)}
 

--- a/components/pickup/TimeslotSelector.tsx
+++ b/components/pickup/TimeslotSelector.tsx
@@ -44,8 +44,17 @@ interface TimeslotResponse {
 	hasMore: boolean;
 }
 
+interface CurrentTimeslot {
+	date: string;
+	startTime: string;
+	endTime: string;
+	label?: string;
+}
+
 interface TimeslotSelectorProps {
 	orderId: string;
+	/** If provided, indicates the user is changing an existing timeslot. */
+	currentTimeslot?: CurrentTimeslot | null;
 	onTimeslotSelected: (
 		timeslotId: string,
 		pickupInstructions?: unknown[],
@@ -106,9 +115,11 @@ async function fetchTimeslots(page: number): Promise<TimeslotResponse> {
  */
 export function TimeslotSelector({
 	orderId,
+	currentTimeslot,
 	onTimeslotSelected,
 	onCancel,
 }: TimeslotSelectorProps) {
+	const isChanging = !!currentTimeslot;
 	const [selectedId, setSelectedId] = useState<string | null>(null);
 	const [submitting, setSubmitting] = useState(false);
 	const [submitError, setSubmitError] = useState<string | null>(null);
@@ -204,8 +215,35 @@ export function TimeslotSelector({
 			transition="opacity 0.15s ease"
 		>
 			<Heading size="md" mb={4}>
-				Select a Pickup Timeslot
+				{isChanging ? "Change Pickup Timeslot" : "Select a Pickup Timeslot"}
 			</Heading>
+
+			{/* Show current timeslot when changing */}
+			{isChanging && currentTimeslot && (
+				<Box
+					p={4}
+					mb={5}
+					bg="orange.50"
+					borderRadius="lg"
+					borderLeft="4px solid"
+					borderLeftColor="orange.400"
+				>
+					<Text fontSize="xs" fontWeight={700} color="orange.700" mb={1}>
+						CURRENT TIMESLOT
+					</Text>
+					<Text fontWeight={600} fontSize="sm">
+						{formatDateHeading(
+							currentTimeslot.date.includes("T")
+								? currentTimeslot.date.split("T")[0]
+								: currentTimeslot.date,
+						)}
+					</Text>
+					<Text fontSize="sm" color="gray.600">
+						{currentTimeslot.startTime} – {currentTimeslot.endTime}
+						{currentTimeslot.label ? ` · ${currentTimeslot.label}` : ""}
+					</Text>
+				</Box>
+			)}
 
 			{submitError && (
 				<Alert status="error" mb={3} borderRadius="md">
@@ -328,9 +366,9 @@ export function TimeslotSelector({
 					onClick={handleSubmit}
 					isDisabled={!selectedId || submitting}
 					isLoading={submitting}
-					loadingText="Confirming..."
+					loadingText={isChanging ? "Updating..." : "Confirming..."}
 				>
-					Confirm Timeslot
+					{isChanging ? "Update Timeslot" : "Confirm Timeslot"}
 				</Button>
 				<Button variant="outline" onClick={onCancel}>
 					Cancel


### PR DESCRIPTION
## Changes

When a user already has a pickup timeslot and navigates to change it, the UI now clearly communicates they are **changing** rather than selecting for the first time.

### TimeslotSelector
- New optional `currentTimeslot` prop
- Displays an orange **"CURRENT TIMESLOT"** card at the top showing the existing date, time, and label
- Heading: **"Change Pickup Timeslot"** vs "Select a Pickup Timeslot"
- Button: **"Update Timeslot"** / "Updating..." vs "Confirm Timeslot" / "Confirming..."

### OrderSteps
- Passes `orderDetails.pickupTimeslot` to `TimeslotSelector` so it knows the current selection
- Step heading: **"📍 Change Pickup Time"** vs "📍 Select Pickup Time"
- Description: **"already has a pickup time. Select a new timeslot below."** vs "has been paid. Choose when you'd like to collect it."

### Behaviour
- First-time selection (order just paid): shows the original select UI, no current timeslot card
- Changing timeslot (order already in AWAITING_PICKUP): shows the current timeslot prominently, with change-oriented language throughout

## Files changed
- `components/pickup/TimeslotSelector.tsx`
- `components/ordercontainer/OrderSteps.tsx`