### PR TITLE
Attempt to fix slow loading times on slow connections

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -13,7 +13,19 @@ import { getPayloadClient } from "@/lib/payload";
  *
  * The route touches `getPayloadClient()` (which caches its connection promise)
  * so the ping also keeps the Payload/Mongo layer warm, not just the HTTP
- * server. It is intentionally cheap: it does not run any queries.
+ * server. It then issues ONE deliberately cheap query (a `count` capped at a
+ * single document) against MongoDB.
+ *
+ * Why run a query at all? Warming `getPayloadClient()` only proves the cached
+ * connection *promise* resolved — it does not prove the underlying pooled
+ * socket is still alive and the database is actually reachable. A minimal
+ * round-trip both (a) exercises a real pinned socket so the keep-warm cron
+ * genuinely keeps the connection hot end-to-end, and (b) turns this endpoint
+ * into a true readiness probe that reports `db: false` when MongoDB is down
+ * instead of a false `db: true` on a stale connection. The `count` bypasses
+ * access control (`overrideAccess`) and never fetches document bodies — it
+ * only asks MongoDB for a collection count, which is the cheapest possible
+ * round-trip that still touches the wire.
  *
  * Kept public (not matched by middleware.ts, which only guards /api/shop/*).
  */
@@ -25,10 +37,16 @@ export const runtime = "nodejs";
 export async function GET(): Promise<NextResponse> {
 	let db = false;
 	try {
-		// Warms (and reuses) the cached Payload/Mongo connection. Swallow
-		// errors so a transient DB blip never turns the keep-warm ping into a
-		// hard failure that could mark the container unhealthy.
-		await getPayloadClient();
+		// Warms (and reuses) the cached Payload/Mongo connection, then does a
+		// minimal round-trip to confirm the pooled socket is actually live.
+		// Swallow errors so a transient DB blip never turns the keep-warm ping
+		// into a hard failure that could mark the container unhealthy.
+		const payload = await getPayloadClient();
+		await payload.count({
+			collection: "users",
+			overrideAccess: true,
+			disableErrors: true,
+		});
 		db = true;
 	} catch (error) {
 		console.warn("[health] Payload/Mongo warmup failed:", error);

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -13,8 +13,8 @@ import { getPayloadClient } from "@/lib/payload";
  *
  * The route touches `getPayloadClient()` (which caches its connection promise)
  * so the ping also keeps the Payload/Mongo layer warm, not just the HTTP
- * server. It then issues ONE deliberately cheap query (a `count` capped at a
- * single document) against MongoDB.
+ * server. It then issues ONE deliberately cheap query (a collection `count`)
+ * against MongoDB.
  *
  * Why run a query at all? Warming `getPayloadClient()` only proves the cached
  * connection *promise* resolved — it does not prove the underlying pooled
@@ -24,8 +24,8 @@ import { getPayloadClient } from "@/lib/payload";
  * into a true readiness probe that reports `db: false` when MongoDB is down
  * instead of a false `db: true` on a stale connection. The `count` bypasses
  * access control (`overrideAccess`) and never fetches document bodies — it
- * only asks MongoDB for a collection count, which is the cheapest possible
- * round-trip that still touches the wire.
+ * only asks MongoDB for a collection count, which is a cheap round-trip that
+ * still touches the wire.
  *
  * Kept public (not matched by middleware.ts, which only guards /api/shop/*).
  */

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { getPayloadClient } from "@/lib/payload";
+
+/**
+ * Lightweight health / keep-warm endpoint.
+ *
+ * Purpose: this app runs inside a Cloudflare Container that scales to zero.
+ * A scheduled Worker Cron Trigger (see the `scheduled` handler in
+ * container-worker.js) pings this route periodically so the container stays
+ * running with an already-established MongoDB connection pool. That way real
+ * visitors reuse a warm process instead of paying the container boot +
+ * Next.js start + Mongo connect/init on their first request.
+ *
+ * The route touches `getPayloadClient()` (which caches its connection promise)
+ * so the ping also keeps the Payload/Mongo layer warm, not just the HTTP
+ * server. It is intentionally cheap: it does not run any queries.
+ *
+ * Kept public (not matched by middleware.ts, which only guards /api/shop/*).
+ */
+
+// Always run dynamically on the Node runtime — never cache or prerender.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(): Promise<NextResponse> {
+	let db = false;
+	try {
+		// Warms (and reuses) the cached Payload/Mongo connection. Swallow
+		// errors so a transient DB blip never turns the keep-warm ping into a
+		// hard failure that could mark the container unhealthy.
+		await getPayloadClient();
+		db = true;
+	} catch (error) {
+		console.warn("[health] Payload/Mongo warmup failed:", error);
+	}
+
+	return NextResponse.json(
+		{ status: "ok", db, timestamp: new Date().toISOString() },
+		{ headers: { "Cache-Control": "no-store" } },
+	);
+}

--- a/container-worker.js
+++ b/container-worker.js
@@ -13,6 +13,17 @@ import { Container, getContainer } from "@cloudflare/containers";
 export class PrimalPrinting extends Container {
 	defaultPort = 3000;
 
+	// Keep a warmed instance alive well past the default idle timeout so the
+	// container does NOT scale to zero during normal gaps in traffic. Every
+	// scale-to-zero forces the next visitor to pay the full container boot +
+	// Next.js start + MongoDB connect/init on the critical path (the "insanely
+	// long load / timeout for the first user" symptom). With `sleepAfter` the
+	// instance only sleeps after a genuinely idle window, so the vast majority
+	// of visitors reuse an already-running process with pooled Mongo
+	// connections. Trade-off: a warm instance accrues (cheap) idle billing —
+	// acceptable here for a single low-traffic storefront (max_instances: 1).
+	sleepAfter = "20m";
+
 	// Called when a new container instance starts — use to pass secrets
 	// and env vars from the Worker environment into the container.
 	envVars = {
@@ -70,5 +81,31 @@ export default {
 		const containerInstance = getContainer(env.APP, id);
 		// Pass the request to the container instance on its default port
 		return containerInstance.fetch(request);
+	},
+
+	/**
+	 * Cron Trigger handler (see `triggers.crons` in wrangler.jsonc).
+	 *
+	 * Keep-warm ping: periodically hits the container's `/api/health` endpoint
+	 * so the singleton instance never sits idle long enough to scale to zero
+	 * (which, together with `sleepAfter` on the Container class, keeps the
+	 * MongoDB connection pool alive). This eliminates the cold-start penalty —
+	 * container boot + Next.js start + Mongo connect/init — that otherwise lands
+	 * on the first real visitor after an idle period.
+	 *
+	 * Unlike GitHub Actions cron (min ~5min, frequently delayed and needs an
+	 * external URL + shared secret), Worker Cron Triggers fire reliably and can
+	 * reach the container directly through the Durable Object stub — no public
+	 * request, no auth secret required.
+	 */
+	async scheduled(_event, env, ctx) {
+		const containerInstance = getContainer(env.APP, "singleton");
+		const warm = containerInstance
+			.fetch(new Request("https://internal/api/health"))
+			.then(() => undefined)
+			.catch((error) => {
+				console.warn("[keep-warm] health ping failed:", error);
+			});
+		ctx.waitUntil(warm);
 	},
 };

--- a/container-worker.js
+++ b/container-worker.js
@@ -102,13 +102,22 @@ export default {
 	 *
 	 * Unlike GitHub Actions cron (min ~5min, frequently delayed and needs an
 	 * external URL + shared secret), Worker Cron Triggers fire reliably and can
-	 * reach the container directly through the Durable Object stub — no public
-	 * request, no auth secret required.
+	 * reach the container directly through the Durable Object stub — the ping
+	 * never leaves Cloudflare's network and needs no auth secret (the URL below
+	 * uses the public origin only to satisfy `global_fetch_strictly_public`).
 	 */
 	async scheduled(_event, env, ctx) {
 		const containerInstance = getContainer(env.APP, "singleton");
+		// `containerInstance.fetch()` always routes internally via the Durable
+		// Object stub regardless of the request URL, so the hostname here is only
+		// used to construct a valid Request. Use the site's public origin (not a
+		// made-up hostname like `https://internal/...`): the
+		// `global_fetch_strictly_public` compatibility flag in wrangler.jsonc can
+		// reject non-public hostnames, which would break the keep-warm ping.
+		const baseUrl = env.NEXT_PUBLIC_BASE_URL || "https://primalprinting.co.nz";
+		const healthUrl = new URL("/api/health", baseUrl).toString();
 		const warm = containerInstance
-			.fetch(new Request("https://internal/api/health"))
+			.fetch(new Request(healthUrl))
 			.then(() => undefined)
 			.catch((error) => {
 				console.warn("[keep-warm] health ping failed:", error);

--- a/container-worker.js
+++ b/container-worker.js
@@ -75,10 +75,17 @@ export class PrimalPrinting extends Container {
 
 export default {
 	async fetch(request, env) {
-		const url = new URL(request.url);
-		const id = url.searchParams.get("id") || "singleton";
-		// Get the container instance for the given session ID
-		const containerInstance = getContainer(env.APP, id);
+		// Always route to the single "singleton" instance. This app runs with
+		// `max_instances: 1`, and the keep-warm cron (see `scheduled` below)
+		// only pings the "singleton" instance. Previously the instance id was
+		// derived from a `?id=` query param, so any request carrying an `id`
+		// would be routed to a DIFFERENT, cold container instance that the
+		// keep-warm ping never touched — that visitor would then pay the full
+		// container boot + Next.js start + Mongo connect/init on their critical
+		// path (the exact long-load / timeout symptom). Pinning every request
+		// to "singleton" guarantees all traffic reuses the one warm process
+		// with its live MongoDB connection pool.
+		const containerInstance = getContainer(env.APP, "singleton");
 		// Pass the request to the container instance on its default port
 		return containerInstance.fetch(request);
 	},

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -14,16 +14,20 @@
  * first user. Warming here overlaps that cost with the server's own boot.
  *
  * The warmup is:
- *   - Node.js runtime only (skipped on the Edge runtime, which has no Mongo).
+ *   - Skipped only on the Edge runtime (which has no Mongo); runs on the Node
+ *     server runtime by default even if `NEXT_RUNTIME` is unset.
  *   - Fire-and-forget: it never blocks server startup and swallows errors so a
  *     transient DB hiccup at boot can't crash the process. `getPayloadClient`
  *     caches its promise, so the first real request simply awaits the same
  *     (already in-flight or resolved) connection.
  */
 export async function register(): Promise<void> {
-	// Only warm on the Node.js server runtime — the Edge runtime cannot talk to
-	// MongoDB and has no access to the Payload local API.
-	if (process.env.NEXT_RUNTIME !== "nodejs") {
+	// Skip only on the Edge runtime, which cannot talk to MongoDB and has no
+	// access to the Payload local API. We deliberately check for an explicit
+	// "edge" value rather than requiring `=== "nodejs"`: `NEXT_RUNTIME` may be
+	// unset in some instrumentation-hook environments, and in that case we still
+	// want to warm on the Node server runtime by default rather than skip it.
+	if (process.env.NEXT_RUNTIME === "edge") {
 		return;
 	}
 

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,45 @@
+/**
+ * Next.js instrumentation hook.
+ *
+ * `register()` is invoked exactly once when the server process boots — before
+ * any request is handled. We use it to eagerly warm the Payload CMS / MongoDB
+ * connection so the FIRST visitor after a cold container start doesn't pay the
+ * full connect + Mongoose model-registration cost inline with their request.
+ *
+ * Background: this app runs as a standalone Next.js server inside a Cloudflare
+ * Container that can scale to zero. When it spins back up, the very first
+ * request would otherwise trigger `getPayloadClient()` for the first time,
+ * incurring the MongoDB handshake and Payload initialisation on the critical
+ * path — the source of the very long / timeout-prone loads reported for that
+ * first user. Warming here overlaps that cost with the server's own boot.
+ *
+ * The warmup is:
+ *   - Node.js runtime only (skipped on the Edge runtime, which has no Mongo).
+ *   - Fire-and-forget: it never blocks server startup and swallows errors so a
+ *     transient DB hiccup at boot can't crash the process. `getPayloadClient`
+ *     caches its promise, so the first real request simply awaits the same
+ *     (already in-flight or resolved) connection.
+ */
+export async function register(): Promise<void> {
+	// Only warm on the Node.js server runtime — the Edge runtime cannot talk to
+	// MongoDB and has no access to the Payload local API.
+	if (process.env.NEXT_RUNTIME !== "nodejs") {
+		return;
+	}
+
+	// Skip if there is no database configured (e.g. build/CI environments) to
+	// avoid a pointless 5s serverSelectionTimeout at boot.
+	if (!process.env.DATABASE_URI) {
+		return;
+	}
+
+	try {
+		const { getPayloadClient } = await import("./lib/payload");
+		// Fire-and-forget: kick off initialisation but don't block boot on it.
+		void getPayloadClient().catch((error) => {
+			console.warn("[instrumentation] Payload warmup failed:", error);
+		});
+	} catch (error) {
+		console.warn("[instrumentation] Payload warmup could not start:", error);
+	}
+}

--- a/lib/payload.ts
+++ b/lib/payload.ts
@@ -18,10 +18,19 @@ let cachedPromise: Promise<Payload> | null = null;
  *
  * A timeout wrapper ensures the Worker never hangs indefinitely if the
  * database is unreachable.
+ *
+ * Failure handling: we cache the in-flight promise (so concurrent callers
+ * share one initialisation), but if it REJECTS — e.g. a transient MongoDB
+ * slowdown trips the init timeout, or a momentary network blip during a cold
+ * connect — we clear the cache so the next call retries with a fresh attempt.
+ * Without this, a single slow/failed cold connect would poison `cachedPromise`
+ * permanently: every subsequent request (and the keep-warm ping) would get the
+ * cached rejection instantly and the container could never recover until it was
+ * restarted, turning a momentary blip into a hard outage.
  */
 export const getPayloadClient = async (): Promise<Payload> => {
 	if (!cachedPromise) {
-		cachedPromise = Promise.race([
+		const attempt = Promise.race([
 			getPayload({ config: configPromise }),
 			new Promise<never>((_, reject) =>
 				setTimeout(
@@ -30,6 +39,15 @@ export const getPayloadClient = async (): Promise<Payload> => {
 				),
 			),
 		]);
+		// Only keep the cache if initialisation succeeds. On failure, drop it
+		// so a later request/ping can retry instead of being served a
+		// permanently-cached rejection.
+		attempt.catch(() => {
+			if (cachedPromise === attempt) {
+				cachedPromise = null;
+			}
+		});
+		cachedPromise = attempt;
 	}
 	return cachedPromise;
 };

--- a/payload.config.ts
+++ b/payload.config.ts
@@ -38,6 +38,20 @@ export default (async () =>
 				serverSelectionTimeoutMS: 5000,
 				connectTimeoutMS: 5000,
 				socketTimeoutMS: 10000,
+				// Disable Mongoose autoIndex in production. By default the mongodb
+				// adapter connects with `autoIndex: true`, which makes Mongoose
+				// verify/build the indexes for EVERY collection (Users, Customers,
+				// Orders, Timeslots, Schedules, …) against MongoDB right after the
+				// connection opens. On a cold container start that first request
+				// pays the cost of all those index round-trips, producing the very
+				// long / timeout-prone loads reported for the first visitor after
+				// the container scales back up.
+				//
+				// Indexes should instead be created once (via `payload migrate` or
+				// a one-off admin login), not rebuilt on every cold connect. We
+				// keep autoIndex enabled in development so schema/index changes are
+				// picked up automatically while iterating locally.
+				autoIndex: process.env.NODE_ENV !== "production",
 			},
 		}),
 		editor: lexicalEditor(),

--- a/payload.config.ts
+++ b/payload.config.ts
@@ -38,6 +38,21 @@ export default (async () =>
 				serverSelectionTimeoutMS: 5000,
 				connectTimeoutMS: 5000,
 				socketTimeoutMS: 10000,
+				// Keep a warm pool of sockets pinned open. The MongoDB driver
+				// defaults to `minPoolSize: 0`, which means every socket the
+				// pool opens is torn down once it goes idle — so even though
+				// the container is kept warm (see container-worker.js /
+				// wrangler cron), a visitor arriving after a quiet gap would
+				// still pay a full TLS + SCRAM auth handshake to (re)open a
+				// connection. Pinning a minimum pool keeps authenticated
+				// sockets alive between the keep-warm pings, so real requests
+				// reuse an established connection instead of re-handshaking.
+				// `maxIdleTimeMS: 0` (the default) means pooled sockets are
+				// never expired for idleness; we set it explicitly for clarity
+				// alongside the min pool so the intent survives future edits.
+				minPoolSize: 2,
+				maxPoolSize: 10,
+				maxIdleTimeMS: 0,
 				// Disable Mongoose autoIndex in production. By default the mongodb
 				// adapter connects with `autoIndex: true`, which makes Mongoose
 				// verify/build the indexes for EVERY collection (Users, Customers,

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -86,6 +86,15 @@
 			}
 		]
 	},
+	// Keep-warm Cron Trigger. Fires the Worker's `scheduled` handler (see
+	// container-worker.js), which pings the container's /api/health endpoint so
+	// the singleton instance never idles long enough to scale to zero. Every 5
+	// minutes sits comfortably inside the Container class's `sleepAfter` window,
+	// so a warm process with a live MongoDB pool is always ready — no cold-start
+	// connect/init on the first real visitor's critical path.
+	"triggers": {
+		"crons": ["*/5 * * * *"]
+	},
 	"images": {
 		"binding": "IMAGES"
 	},


### PR DESCRIPTION
- **gnhf 2: Fixed MongoDB cold-start slowness by disabling production Mongoose autoIndex and warming the Payload connection at container boot via a Next.js instrumentation hook.**
- **gnhf 3: Eliminated Cloudflare Container cold starts by keeping the instance warm via a Container sleepAfter window plus a Worker Cron Trigger that pings a new /api/health endpoint.**
- **gnhf 4: Pinned a warm MongoDB connection pool and fixed container routing so all traffic reuses the single kept-warm instance, eliminating per-request re-handshakes and stray cold instances.**
- **gnhf 5: Made the cached Payload/Mongo init promise self-healing so a transient slow/failed cold connect no longer poisons the cache permanently and blocks all subsequent requests.**
- **gnhf 6: Upgraded the keep-warm/health endpoint to run a minimal real MongoDB round-trip (payload.count) so it genuinely keeps a pinned socket live and acts as a true readiness probe instead of only resolving the cached connection promise.**
