### PR TITLE
fix: guard Stripe pricing path against undefined default_price crash during order upload

### DIFF
--- a/app/api/shop/orders/route.ts
+++ b/app/api/shop/orders/route.ts
@@ -275,7 +275,7 @@ export async function POST(request: NextRequest) {
 			error instanceof Error ? error.message : "Failed to create order.";
 		const isUserError =
 			error instanceof Error &&
-			/please|must|exceeds|unsupported|empty|not received|valid PDF/i.test(
+			/please|must|exceeds|unsupported|empty|not received|valid PDF|no print product is configured|no default price configured|stripe catalogue/i.test(
 				error.message,
 			);
 		return NextResponse.json(

--- a/components/ordercontainer/PdfOrder.tsx
+++ b/components/ordercontainer/PdfOrder.tsx
@@ -52,6 +52,12 @@ const PdfOrder = () => {
 			(res) =>
 				res.json().then((data) => {
 					console.log(data);
+					if (!data.success || data.priceId == null || data.price == null) {
+						window.alert(
+							"We couldn't work out a price for this file right now. Please try again, or contact us if the problem persists.",
+						);
+						return;
+					}
 					toChange.isColor = option;
 					toChange.priceId = data.priceId;
 					toChange.setUnitPrice(data.price / 100);
@@ -83,6 +89,16 @@ const PdfOrder = () => {
 								`/api/shop?pages=${pages}&isColor=${DEFAULT_IS_COLOR}`,
 							).then((res) =>
 								res.json().then((data) => {
+									if (
+										!data.success ||
+										data.price == null ||
+										data.priceId == null
+									) {
+										window.alert(
+											"We couldn't work out a price for this file right now. Please try again, or contact us if the problem persists.",
+										);
+										return;
+									}
 									if (Number.isNaN(data.price)) {
 										window.alert(
 											"Pdf is over 400 pages, please email us the pdf and we can arrange something.",

--- a/components/ordercontainer/PdfOrder.tsx
+++ b/components/ordercontainer/PdfOrder.tsx
@@ -47,7 +47,12 @@ const PdfOrder = () => {
 		);
 		const temp = [...uploadedPdfs];
 		const toChange = temp[idx];
-		console.log(option);
+		// Guard against the item no longer being in the cart: temp[-1] is
+		// undefined and would crash with "cannot read properties of undefined"
+		// on the toChange.getPages()/property access below.
+		if (idx === -1 || !toChange) {
+			return;
+		}
 		fetch(`/api/shop?pages=${toChange.getPages()}&isColor=${option}`)
 			.then((res) =>
 				res.json().then((data) => {

--- a/components/ordercontainer/PdfOrder.tsx
+++ b/components/ordercontainer/PdfOrder.tsx
@@ -48,8 +48,8 @@ const PdfOrder = () => {
 		const temp = [...uploadedPdfs];
 		const toChange = temp[idx];
 		console.log(option);
-		fetch(`/api/shop?pages=${toChange.getPages()}&isColor=${option}`).then(
-			(res) =>
+		fetch(`/api/shop?pages=${toChange.getPages()}&isColor=${option}`)
+			.then((res) =>
 				res.json().then((data) => {
 					console.log(data);
 					if (!data.success || data.priceId == null || data.price == null) {
@@ -63,7 +63,16 @@ const PdfOrder = () => {
 					toChange.setUnitPrice(data.price / 100);
 					updateUploadedPdf(toChange);
 				}),
-		);
+			)
+			.catch((err) => {
+				// A rejected request or a non-JSON error response must not leave
+				// the item in an inconsistent state or surface as an unhandled
+				// rejection — surface a clear message instead.
+				console.error("Failed to reprice file on colour change:", err);
+				window.alert(
+					"We couldn't work out a price for this file right now. Please try again, or contact us if the problem persists.",
+				);
+			});
 	};
 	const _handleDragOver = useCallback(
 		(e: { preventDefault: () => void; stopPropagation: () => void }) => {

--- a/components/ordercontainer/PdfOrder.tsx
+++ b/components/ordercontainer/PdfOrder.tsx
@@ -94,7 +94,11 @@ const PdfOrder = () => {
 						.then((pdfjs) => pdfjs.getDocument(src).promise)
 						.then((doc) => {
 							pages = doc.numPages;
-							fetch(
+							// Return the fetch promise so a rejected request or a
+							// non-JSON error response propagates to the outer
+							// .catch() below instead of becoming an unhandled
+							// rejection during the initial upload.
+							return fetch(
 								`/api/shop?pages=${pages}&isColor=${DEFAULT_IS_COLOR}`,
 							).then((res) =>
 								res.json().then((data) => {

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -25,6 +25,11 @@ export const findPrice = async (priceId: string) => {
  *   - type: "Colour" or "B/W"
  */
 export const getPriceForPages = async (pages: number, isColor: boolean) => {
+	if (!Number.isFinite(pages) || pages < 1) {
+		throw new Error(
+			`Page count must be a positive number; received "${pages}". The uploaded file may be empty or could not be read.`,
+		);
+	}
 	const stripe: Stripe = await makeStripeConnection();
 	const pageRange = { maxPages: -1, minPages: -1 };
 	const updatePageRange = (minPages: number, maxPages: number): void => {

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -61,7 +61,7 @@ export const getPriceForPages = async (pages: number, isColor: boolean) => {
 	const products = await stripe.products.search({
 		query: `metadata["maxPages"]:'${pageRange.maxPages}' AND metadata["minPages"]:'${pageRange.minPages}' AND metadata["type"]:${isColor ? "'Colour'" : "'B/W'"}`,
 	});
-	const product = products.data[0];
+	const product = products?.data?.[0];
 	if (!product) {
 		throw new Error(
 			`No print product is configured for ${pages} page(s) (${

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -56,9 +56,24 @@ export const getPriceForPages = async (pages: number, isColor: boolean) => {
 	const products = await stripe.products.search({
 		query: `metadata["maxPages"]:'${pageRange.maxPages}' AND metadata["minPages"]:'${pageRange.minPages}' AND metadata["type"]:${isColor ? "'Colour'" : "'B/W'"}`,
 	});
-	const priceId = products.data[0].default_price?.toString();
-	const price = await findPrice(priceId || "");
-	const productId = products.data[0].id;
+	const product = products.data[0];
+	if (!product) {
+		throw new Error(
+			`No print product is configured for ${pages} page(s) (${
+				pageRange.minPages
+			}-${pageRange.maxPages}, ${
+				isColor ? "Colour" : "B/W"
+			}) in the Stripe catalogue.`,
+		);
+	}
+	const priceId = product.default_price?.toString();
+	if (!priceId) {
+		throw new Error(
+			`Print product "${product.id}" has no default price configured in the Stripe catalogue.`,
+		);
+	}
+	const price = await findPrice(priceId);
+	const productId = product.id;
 	return {
 		price: price,
 		priceId: priceId,

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -14,7 +14,23 @@ const makeStripeConnection = async () => {
 
 export const findPrice = async (priceId: string) => {
 	const stripe: Stripe = await makeStripeConnection();
-	const price = await stripe.prices.retrieve(priceId);
+	let price: Stripe.Price | Stripe.DeletedPrice;
+	try {
+		price = await stripe.prices.retrieve(priceId);
+	} catch (_error) {
+		// A product may reference a price that has since been deleted/archived
+		// or is otherwise unretrievable. Surface this as a descriptive
+		// catalogue error rather than an opaque Stripe 500 so the caller can
+		// classify it as a user-actionable configuration problem.
+		throw new Error(
+			`Price "${priceId}" could not be retrieved from the Stripe catalogue.`,
+		);
+	}
+	if (price.deleted) {
+		throw new Error(
+			`Price "${priceId}" has been deleted in the Stripe catalogue.`,
+		);
+	}
 	return price.unit_amount;
 };
 

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -73,6 +73,11 @@ export const getPriceForPages = async (pages: number, isColor: boolean) => {
 		);
 	}
 	const price = await findPrice(priceId);
+	if (price == null) {
+		throw new Error(
+			`Print product "${product.id}" price "${priceId}" has no unit amount configured in the Stripe catalogue.`,
+		);
+	}
 	const productId = product.id;
 	return {
 		price: price,

--- a/pages/api/shop.ts
+++ b/pages/api/shop.ts
@@ -46,8 +46,18 @@ export default async function handler(
 				success: false,
 			});
 		}
-		return res.status(500).json({
-			message: error instanceof Error ? error.message : "Unknown error",
+		// Catalogue/pricing misconfiguration errors thrown by getPriceForPages
+		// (no matching product, no default price, no unit amount, invalid page
+		// count) are user-actionable — surface them as 400 with the descriptive
+		// message rather than an opaque 500, matching the App Router order route.
+		const message = error instanceof Error ? error.message : "Unknown error";
+		const isUserError =
+			error instanceof Error &&
+			/please|must|exceeds|unsupported|empty|not received|valid PDF|no print product is configured|no default price configured|stripe catalogue/i.test(
+				error.message,
+			);
+		return res.status(isUserError ? 400 : 500).json({
+			message,
 			success: false,
 		});
 	}


### PR DESCRIPTION
## Summary

Fixes the `cannot read properties of undefined (reading 'default_price')` crash (and related silent pricing failures) that hit **some users** when initially uploading a PDF / creating an order. The root cause is Stripe catalogue lookups in `getPriceForPages` returning empty/malformed/misconfigured data that was read unguarded, plus inconsistent error status-code handling and unguarded client-side pricing fetches.

This PR hardens the entire live upload/order-creation pricing path across both API entry points (Pages Router `pages/api/shop.ts` and App Router `app/api/shop/orders/route.ts`) and the client `PdfOrder.tsx`.

## Changes

**`lib/stripe.ts` (`getPriceForPages` / `findPrice`)**
- Guard against an empty/malformed Stripe product search (`products?.data?.[0]` undefined) with a descriptive "No print product is configured … in the Stripe catalogue" error instead of an undefined-read crash.
- Guard against a product with no `default_price` configured.
- Guard `findPrice` against deleted/unretrievable Stripe prices (try/catch + `price.deleted` check) so an archived price surfaces a clear error rather than an opaque 500.
- Guard against a `null` `unit_amount` so an unpriced product fails loudly instead of silently producing a $0 total.
- Validate page count up front (finite, `>= 1`) so an unreadable/empty PDF fails with a clear message.

**`app/api/shop/orders/route.ts`**
- Extended the `isUserError` regex so catalogue/default-price/unit-amount/page-count errors return **HTTP 400** with the descriptive message instead of a generic 500.

**`pages/api/shop.ts`**
- Replaced the blanket 500 catch-all with the same `isUserError` classification so upload-time pricing errors match the App Router route (400 + descriptive message).

**`components/ordercontainer/PdfOrder.tsx`**
- Null-check pricing responses in `handlePdfUpload` and `handleColorChange` so a failed price lookup aborts with an alert instead of adding a broken cart item (`NaN` price / `undefined` priceId).
- Added `.catch()` and propagated the inner fetch promise so rejected/non-JSON pricing responses fail gracefully instead of becoming unhandled promise rejections.
- Guard `handleColorChange` against a missing cart item (`idx === -1`) to prevent an undefined-property crash; removed a stray debug `console.log`.

## Validation

The repo has no test framework, so validation was limited to `biome check` and `tsc --noEmit` — both pass on all four modified files.

## Notes

The remaining potential root cause is Stripe **catalogue misconfiguration data** (missing products, missing/deleted prices, null unit amounts) rather than code — those cases now surface as clear, user-actionable 400 errors.

_Generated from `.gnhf/runs/some-users-face-the-158cee-1/notes.md` (iterations 1–12)._
