### PR TITLE
Admin: Create Order for Customer flow

### DIFF
--- a/app/(payload)/admin/importMap.js
+++ b/app/(payload)/admin/importMap.js
@@ -28,6 +28,7 @@ import { default as default_e67e040884f73da757168d32ed5b3a48 } from '@/component
 import { default as default_f5da5fa50c48fc2ef14afcb84f969fcf } from '@/components/admin/AdminNavLinks'
 import { S3ClientUploadHandler as S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24 } from '@payloadcms/storage-s3/client'
 import { default as default_2a932438fc60530ff9cbda67fae50c5e } from '@/components/admin/OrdersByTimeslotView'
+import { default as default_createorderview01234567890abcdef } from '@/components/admin/CreateOrderView'
 import { default as default_ae6d727f69bea18ad23ef405314d6459 } from '@/components/admin/PendingVerificationView'
 import { default as default_357e94cb16882b41b62ce8427705d759 } from '@/components/admin/NotifyTimeslotsView'
 import { default as default_f0bf1af8c7fcbee7729125193a4368fe } from '@/components/admin/ScheduleCalendarView'
@@ -65,6 +66,7 @@ export const importMap = {
   "@/components/admin/AdminNavLinks#default": default_f5da5fa50c48fc2ef14afcb84f969fcf,
   "@payloadcms/storage-s3/client#S3ClientUploadHandler": S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24,
   "@/components/admin/OrdersByTimeslotView#default": default_2a932438fc60530ff9cbda67fae50c5e,
+  "@/components/admin/CreateOrderView#default": default_createorderview01234567890abcdef,
   "@/components/admin/PendingVerificationView#default": default_ae6d727f69bea18ad23ef405314d6459,
   "@/components/admin/NotifyTimeslotsView#default": default_357e94cb16882b41b62ce8427705d759,
   "@/components/admin/ScheduleCalendarView#default": default_f0bf1af8c7fcbee7729125193a4368fe,

--- a/app/(payload)/admin/importMap.js
+++ b/app/(payload)/admin/importMap.js
@@ -25,6 +25,7 @@ import { default as default_cf5df0bc440da11fabc68c09ebfaadac } from '@/component
 import { default as default_1c77336337a4e79b4b5cb9debbef4b54 } from '@/components/admin/MarkPickedUpButton'
 import { default as default_3ec9b1a9218b9b4a731731975ef019e3 } from '@/components/admin/ResendConfirmationButton'
 import { default as default_e67e040884f73da757168d32ed5b3a48 } from '@/components/admin/OrderFilesViewer'
+import { default as default_createorderforcustomerbtn0123456789 } from '@/components/admin/CreateOrderForCustomerButton'
 import { default as default_f5da5fa50c48fc2ef14afcb84f969fcf } from '@/components/admin/AdminNavLinks'
 import { S3ClientUploadHandler as S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24 } from '@payloadcms/storage-s3/client'
 import { default as default_2a932438fc60530ff9cbda67fae50c5e } from '@/components/admin/OrdersByTimeslotView'
@@ -63,6 +64,7 @@ export const importMap = {
   "@/components/admin/MarkPickedUpButton#default": default_1c77336337a4e79b4b5cb9debbef4b54,
   "@/components/admin/ResendConfirmationButton#default": default_3ec9b1a9218b9b4a731731975ef019e3,
   "@/components/admin/OrderFilesViewer#default": default_e67e040884f73da757168d32ed5b3a48,
+  "@/components/admin/CreateOrderForCustomerButton#default": default_createorderforcustomerbtn0123456789,
   "@/components/admin/AdminNavLinks#default": default_f5da5fa50c48fc2ef14afcb84f969fcf,
   "@payloadcms/storage-s3/client#S3ClientUploadHandler": S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24,
   "@/components/admin/OrdersByTimeslotView#default": default_2a932438fc60530ff9cbda67fae50c5e,

--- a/app/api/admin/customers/route.ts
+++ b/app/api/admin/customers/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server";
+import type { Where } from "payload";
 import { isPayloadAdmin } from "../../../../lib/auth";
 import { getPayloadClient } from "../../../../lib/payload";
 
@@ -31,7 +32,7 @@ export async function GET(request: NextRequest) {
 	try {
 		const payload = await getPayloadClient();
 
-		const where = search
+		const where: Where = search
 			? {
 					or: [{ email: { contains: search } }, { name: { contains: search } }],
 				}

--- a/app/api/admin/customers/route.ts
+++ b/app/api/admin/customers/route.ts
@@ -5,10 +5,12 @@ import { getPayloadClient } from "../../../../lib/payload";
 
 /**
  * GET /api/admin/customers?search=...&limit=...
+ * GET /api/admin/customers?id=...
  *
- * Admin-only endpoint that searches customers by email or name. Used by the
- * "manually create order" admin view to pick the customer an order should be
- * created for. Returns a lightweight list — no order data.
+ * Admin-only endpoint that searches customers by email or name, or fetches a
+ * single customer by id. Used by the "manually create order" admin view to pick
+ * (or pre-select) the customer an order should be created for. Returns a
+ * lightweight list — no order data.
  */
 
 export const runtime = "nodejs";
@@ -23,6 +25,7 @@ export async function GET(request: NextRequest) {
 	}
 
 	const { searchParams } = new URL(request.url);
+	const id = (searchParams.get("id") ?? "").trim();
 	const search = (searchParams.get("search") ?? "").trim();
 	const limitRaw = Number.parseInt(searchParams.get("limit") ?? "20", 10);
 	const limit = Number.isFinite(limitRaw)
@@ -31,6 +34,24 @@ export async function GET(request: NextRequest) {
 
 	try {
 		const payload = await getPayloadClient();
+
+		// Single-customer lookup by id — used to pre-select the customer when the
+		// admin deep-links into the create-order view from a customer record.
+		if (id) {
+			const doc = await payload.findByID({
+				collection: "customers",
+				id,
+				depth: 0,
+			});
+			if (!doc) {
+				return NextResponse.json(
+					{ error: "Customer not found." },
+					{ status: 404 },
+				);
+			}
+			const customer = { id: doc.id, email: doc.email, name: doc.name ?? "" };
+			return NextResponse.json({ customers: [customer], total: 1, limit: 1 });
+		}
 
 		const where: Where = search
 			? {

--- a/app/api/admin/customers/route.ts
+++ b/app/api/admin/customers/route.ts
@@ -1,0 +1,66 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { isPayloadAdmin } from "../../../../lib/auth";
+import { getPayloadClient } from "../../../../lib/payload";
+
+/**
+ * GET /api/admin/customers?search=...&limit=...
+ *
+ * Admin-only endpoint that searches customers by email or name. Used by the
+ * "manually create order" admin view to pick the customer an order should be
+ * created for. Returns a lightweight list — no order data.
+ */
+
+export const runtime = "nodejs";
+export const maxDuration = 10;
+
+export async function GET(request: NextRequest) {
+	if (!(await isPayloadAdmin(request))) {
+		return NextResponse.json(
+			{ error: "Admin access required." },
+			{ status: 403 },
+		);
+	}
+
+	const { searchParams } = new URL(request.url);
+	const search = (searchParams.get("search") ?? "").trim();
+	const limitRaw = Number.parseInt(searchParams.get("limit") ?? "20", 10);
+	const limit = Number.isFinite(limitRaw)
+		? Math.min(Math.max(limitRaw, 1), 50)
+		: 20;
+
+	try {
+		const payload = await getPayloadClient();
+
+		const where = search
+			? {
+					or: [{ email: { contains: search } }, { name: { contains: search } }],
+				}
+			: {};
+
+		const result = await payload.find({
+			collection: "customers",
+			where,
+			limit,
+			sort: "-createdAt",
+			depth: 0,
+		});
+
+		const customers = result.docs.map((c) => ({
+			id: c.id,
+			email: c.email,
+			name: c.name ?? "",
+		}));
+
+		return NextResponse.json({
+			customers,
+			total: result.totalDocs,
+			limit,
+		});
+	} catch (error) {
+		console.error("Error searching customers:", error);
+		return NextResponse.json(
+			{ error: "Failed to search customers." },
+			{ status: 500 },
+		);
+	}
+}

--- a/app/api/admin/orders/route.ts
+++ b/app/api/admin/orders/route.ts
@@ -1,0 +1,313 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { isPayloadAdmin } from "../../../../lib/auth";
+import { getPayloadClient } from "../../../../lib/payload";
+import {
+	cleanupStagingFiles,
+	downloadFromStaging,
+	headStagingObject,
+	isCustomerStagingKey,
+} from "../../../../lib/r2";
+import { calculateOrderTotal } from "../../../../lib/stripe";
+import {
+	ALLOWED_FILE_TYPES,
+	MAX_FILE_SIZE_BYTES,
+	MAX_FILE_SIZE_MB,
+	MAX_FILES_PER_ORDER,
+} from "../../../../lib/uploadLimits";
+
+// Run on the Node.js runtime — required for Buffer + the S3 client used by
+// downloadFromStaging.
+export const runtime = "nodejs";
+// HEAD + page-counting downloads of every file can take a while at max size.
+export const maxDuration = 60;
+
+/**
+ * Count PDF pages by scanning for /Type /Page markers in the raw buffer.
+ * Lightweight — no external dependencies, no Object.defineProperty issues.
+ */
+function countPdfPages(buffer: Buffer): number {
+	const text = buffer.toString("latin1");
+	let count = 0;
+	let pos = 0;
+
+	while (true) {
+		const idx = text.indexOf("/Type", pos);
+		if (idx === -1) break;
+
+		const after = text.substring(idx + 5, idx + 30).trimStart();
+		if (after.startsWith("/Page") && !after.startsWith("/Pages")) {
+			count++;
+		}
+		pos = idx + 5;
+	}
+
+	return Math.max(count, 0);
+}
+
+/**
+ * POST /api/admin/orders — Admin-only: manually finalise a DRAFT order on
+ * behalf of a customer from staging files the admin already uploaded directly
+ * to R2 (see /api/admin/orders/staging-urls).
+ *
+ * This exists so an admin can put a customer into the payment stage when the
+ * customer couldn't upload their files on the site themselves. The resulting
+ * order is a plain DRAFT owned by the target customer, so the customer can
+ * resume it via "My Orders" and go through the normal timeslot + payment flow.
+ *
+ * Everything is verified server-side, mirroring the customer route: staging
+ * keys must belong to the target customer, objects are HEADed and downloaded to
+ * count pages, and pricing is computed from the verified counts. Verified
+ * staging objects are cleaned up on failure so they don't linger in R2.
+ */
+export async function POST(request: NextRequest) {
+	if (!(await isPayloadAdmin(request))) {
+		return NextResponse.json(
+			{ error: "Admin access required." },
+			{ status: 403 },
+		);
+	}
+
+	let body: {
+		customerId?: unknown;
+		files?: Array<{
+			stagingKey?: unknown;
+			fileName?: unknown;
+			copies?: unknown;
+			colorMode?: unknown;
+		}>;
+	};
+	try {
+		body = (await request.json()) as typeof body;
+	} catch {
+		return NextResponse.json(
+			{ error: "Request body must be valid JSON." },
+			{ status: 400 },
+		);
+	}
+
+	const customerId =
+		typeof body?.customerId === "string" ? body.customerId : "";
+	if (!customerId) {
+		return NextResponse.json(
+			{ error: "`customerId` is required." },
+			{ status: 400 },
+		);
+	}
+
+	const requestedFiles = body?.files;
+	if (!Array.isArray(requestedFiles) || requestedFiles.length === 0) {
+		return NextResponse.json(
+			{ error: "`files` must be a non-empty array." },
+			{ status: 400 },
+		);
+	}
+
+	if (requestedFiles.length > MAX_FILES_PER_ORDER) {
+		return NextResponse.json(
+			{
+				error: `Too many files (${requestedFiles.length}). Maximum is ${MAX_FILES_PER_ORDER} per order.`,
+			},
+			{ status: 400 },
+		);
+	}
+
+	// Validate the shape of every entry up-front so we don't do any R2 work
+	// on a request that's guaranteed to fail validation later.
+	type ValidatedRequest = {
+		stagingKey: string;
+		fileName: string;
+		copies: number;
+		colorMode: "BW" | "COLOR";
+	};
+	const validated: ValidatedRequest[] = [];
+	for (let i = 0; i < requestedFiles.length; i++) {
+		const f = requestedFiles[i];
+		const stagingKey = typeof f?.stagingKey === "string" ? f.stagingKey : "";
+		const fileName = typeof f?.fileName === "string" ? f.fileName : "";
+		const copiesRaw = typeof f?.copies === "number" ? f.copies : 1;
+		const colorModeRaw = typeof f?.colorMode === "string" ? f.colorMode : "BW";
+
+		if (!stagingKey) {
+			return NextResponse.json(
+				{ error: `files[${i}].stagingKey is required.` },
+				{ status: 400 },
+			);
+		}
+		if (!fileName) {
+			return NextResponse.json(
+				{ error: `files[${i}].fileName is required.` },
+				{ status: 400 },
+			);
+		}
+		if (!isCustomerStagingKey(stagingKey, customerId)) {
+			// The staging key doesn't belong to the target customer. This should
+			// only happen if the client tampered with the finalisation payload.
+			return NextResponse.json(
+				{
+					error: `files[${i}]: staging key does not belong to the target customer.`,
+				},
+				{ status: 400 },
+			);
+		}
+		if (!Number.isFinite(copiesRaw) || copiesRaw < 1 || copiesRaw > 1000) {
+			return NextResponse.json(
+				{
+					error: `files[${i}].copies must be an integer between 1 and 1000.`,
+				},
+				{ status: 400 },
+			);
+		}
+		if (colorModeRaw !== "BW" && colorModeRaw !== "COLOR") {
+			return NextResponse.json(
+				{ error: `files[${i}].colorMode must be "BW" or "COLOR".` },
+				{ status: 400 },
+			);
+		}
+
+		validated.push({
+			stagingKey,
+			fileName,
+			copies: Math.floor(copiesRaw),
+			colorMode: colorModeRaw,
+		});
+	}
+
+	// Track which staging keys we've successfully verified so we can clean
+	// them up if something later fails (e.g. Payload create error).
+	const verifiedKeys: string[] = [];
+
+	try {
+		const payload = await getPayloadClient();
+
+		// Confirm the target customer exists before doing any R2 work.
+		try {
+			await payload.findByID({ collection: "customers", id: customerId });
+		} catch {
+			return NextResponse.json(
+				{ error: "Customer not found." },
+				{ status: 404 },
+			);
+		}
+
+		// Step 1: HEAD every object to confirm the upload completed and read
+		// authoritative size + content-type from R2.
+		const headed = await Promise.all(
+			validated.map(async (v) => {
+				const head = await headStagingObject(v.stagingKey);
+				if (!head) {
+					throw new Error(
+						`"${v.fileName}" was not received by storage. Please try uploading again.`,
+					);
+				}
+				if (head.contentLength === 0) {
+					throw new Error(
+						`"${v.fileName}" arrived as an empty file. Please try uploading again.`,
+					);
+				}
+				if (head.contentLength > MAX_FILE_SIZE_BYTES) {
+					const mb = (head.contentLength / 1024 / 1024).toFixed(1);
+					throw new Error(
+						`"${v.fileName}" is ${mb}MB, which exceeds the ${MAX_FILE_SIZE_MB}MB per-file limit.`,
+					);
+				}
+				if (
+					!ALLOWED_FILE_TYPES.includes(
+						head.contentType as (typeof ALLOWED_FILE_TYPES)[number],
+					)
+				) {
+					throw new Error(
+						`"${v.fileName}" has unsupported type "${head.contentType}". Only PDF files are accepted.`,
+					);
+				}
+				verifiedKeys.push(v.stagingKey);
+				return { ...v, fileSize: head.contentLength };
+			}),
+		);
+
+		// Step 2: Download each PDF and count pages server-side — never trust
+		// client-supplied counts, since pricing depends on them.
+		const orderFiles = await Promise.all(
+			headed.map(async (v) => {
+				const buffer = await downloadFromStaging(v.stagingKey);
+				const pageCount = countPdfPages(buffer);
+				if (pageCount < 1) {
+					throw new Error(
+						`"${v.fileName}": Unable to read PDF. Please ensure it's a valid PDF file.`,
+					);
+				}
+				return {
+					fileName: v.fileName,
+					stagingKey: v.stagingKey,
+					pageCount,
+					copies: v.copies,
+					colorMode: v.colorMode,
+					fileSize: v.fileSize,
+				};
+			}),
+		);
+
+		// Step 3: Calculate pricing server-side.
+		const pricing = await calculateOrderTotal(orderFiles);
+
+		// Step 4: Create the DRAFT order. Expires in 7 days, exactly like a
+		// customer-created order, so the customer can resume it normally.
+		const expiresAt = new Date();
+		expiresAt.setDate(expiresAt.getDate() + 7);
+
+		const order = await payload.create({
+			collection: "orders",
+			data: {
+				customer: customerId,
+				status: "DRAFT",
+				files: orderFiles,
+				pricing: {
+					subtotal: pricing.subtotal,
+					discount: pricing.discount,
+					tax: 0,
+					total: pricing.total,
+				},
+				expiresAt: expiresAt.toISOString(),
+			},
+		});
+
+		return NextResponse.json({
+			success: true,
+			order: {
+				id: order.id,
+				orderNumber: order.orderNumber,
+				status: order.status,
+				pricing: order.pricing,
+				expiresAt: order.expiresAt,
+			},
+		});
+	} catch (error) {
+		console.error("Error creating admin order:", error);
+
+		// Best-effort cleanup of any verified staging objects so we don't
+		// leave orphaned uploads in R2 after a failed finalisation.
+		if (verifiedKeys.length > 0) {
+			cleanupStagingFiles(verifiedKeys.map((k) => ({ stagingKey: k }))).catch(
+				(cleanupErr) => {
+					console.error(
+						"Failed to clean up staging files after admin order error:",
+						cleanupErr,
+					);
+				},
+			);
+		}
+
+		// Pass through descriptive Error messages thrown by the validation /
+		// verification steps; everything else gets a generic 500.
+		const message =
+			error instanceof Error ? error.message : "Failed to create order.";
+		const isUserError =
+			error instanceof Error &&
+			/please|must|exceeds|unsupported|empty|not received|valid PDF/i.test(
+				error.message,
+			);
+		return NextResponse.json(
+			{ error: message },
+			{ status: isUserError ? 400 : 500 },
+		);
+	}
+}

--- a/app/api/admin/orders/staging-urls/route.ts
+++ b/app/api/admin/orders/staging-urls/route.ts
@@ -1,0 +1,161 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { isPayloadAdmin } from "../../../../../lib/auth";
+import { getPayloadClient } from "../../../../../lib/payload";
+import {
+	generateCustomerStagingKey,
+	getPresignedUploadUrl,
+} from "../../../../../lib/r2";
+import {
+	ALLOWED_FILE_TYPES,
+	MAX_FILE_SIZE_BYTES,
+	MAX_FILE_SIZE_MB,
+	MAX_FILES_PER_ORDER,
+	PRESIGN_TTL_SECONDS,
+} from "../../../../../lib/uploadLimits";
+
+/**
+ * POST /api/admin/orders/staging-urls — Admin-only variant of
+ * /api/shop/staging-urls used when an admin manually creates an order on
+ * behalf of a customer (e.g. the customer couldn't upload their files on the
+ * site). Issues presigned PUT URLs so the admin's browser can upload PDFs
+ * directly to the R2 staging bucket.
+ *
+ * The crucial difference from the customer route is that the staging keys are
+ * scoped to an explicit `customerId` (the target customer), not the caller.
+ * This keeps the customer-ownership prefix intact so the later finalisation
+ * step (see /api/admin/orders) can verify the files belong to that customer
+ * and the customer can subsequently resume the order (timeslot + payment).
+ */
+
+export const runtime = "nodejs";
+export const maxDuration = 10;
+
+type RequestedUpload = {
+	name?: unknown;
+	size?: unknown;
+	type?: unknown;
+};
+
+export async function POST(request: NextRequest) {
+	if (!(await isPayloadAdmin(request))) {
+		return NextResponse.json(
+			{ error: "Admin access required." },
+			{ status: 403 },
+		);
+	}
+
+	let body: { customerId?: unknown; files?: RequestedUpload[] };
+	try {
+		body = (await request.json()) as typeof body;
+	} catch {
+		return NextResponse.json(
+			{ error: "Request body must be valid JSON." },
+			{ status: 400 },
+		);
+	}
+
+	const customerId =
+		typeof body?.customerId === "string" ? body.customerId : "";
+	if (!customerId) {
+		return NextResponse.json(
+			{ error: "`customerId` is required." },
+			{ status: 400 },
+		);
+	}
+
+	const files = body?.files;
+	if (!Array.isArray(files) || files.length === 0) {
+		return NextResponse.json(
+			{ error: "`files` must be a non-empty array." },
+			{ status: 400 },
+		);
+	}
+
+	if (files.length > MAX_FILES_PER_ORDER) {
+		return NextResponse.json(
+			{
+				error: `Too many files (${files.length}). Maximum is ${MAX_FILES_PER_ORDER} per order.`,
+			},
+			{ status: 400 },
+		);
+	}
+
+	// Validate every file descriptor up-front so we never issue a partial set
+	// of presigned URLs for an order that's guaranteed to fail later.
+	for (let i = 0; i < files.length; i++) {
+		const f = files[i];
+		const name = typeof f?.name === "string" ? f.name : "";
+		const size = typeof f?.size === "number" ? f.size : Number.NaN;
+		const type = typeof f?.type === "string" ? f.type : "";
+
+		if (!name) {
+			return NextResponse.json(
+				{ error: `files[${i}].name is required and must be a string.` },
+				{ status: 400 },
+			);
+		}
+		if (!Number.isFinite(size) || size <= 0) {
+			return NextResponse.json(
+				{ error: `files[${i}].size must be a positive number of bytes.` },
+				{ status: 400 },
+			);
+		}
+		if (size > MAX_FILE_SIZE_BYTES) {
+			const mb = (size / 1024 / 1024).toFixed(1);
+			return NextResponse.json(
+				{
+					error: `"${name}" is ${mb}MB, which exceeds the ${MAX_FILE_SIZE_MB}MB per-file limit.`,
+				},
+				{ status: 413 },
+			);
+		}
+		if (
+			!ALLOWED_FILE_TYPES.includes(type as (typeof ALLOWED_FILE_TYPES)[number])
+		) {
+			return NextResponse.json(
+				{
+					error: `"${name}" has unsupported type "${type || "unknown"}". Only PDF files are accepted.`,
+				},
+				{ status: 415 },
+			);
+		}
+	}
+
+	// Verify the target customer actually exists before issuing any URLs.
+	try {
+		const payload = await getPayloadClient();
+		await payload.findByID({ collection: "customers", id: customerId });
+	} catch {
+		return NextResponse.json({ error: "Customer not found." }, { status: 404 });
+	}
+
+	try {
+		const uploads = await Promise.all(
+			files.map(async (f) => {
+				const name = f.name as string;
+				const type = f.type as string;
+				const stagingKey = generateCustomerStagingKey(customerId, name);
+				const uploadUrl = await getPresignedUploadUrl(stagingKey, type, {
+					expiresIn: PRESIGN_TTL_SECONDS,
+				});
+				return { stagingKey, uploadUrl, contentType: type };
+			}),
+		);
+
+		return NextResponse.json({
+			uploads,
+			expiresInSeconds: PRESIGN_TTL_SECONDS,
+		});
+	} catch (error) {
+		console.error("Failed to issue admin staging upload URLs:", error);
+		return NextResponse.json(
+			{
+				error:
+					error instanceof Error
+						? `Failed to issue upload URLs: ${error.message}`
+						: "Failed to issue upload URLs.",
+			},
+			{ status: 500 },
+		);
+	}
+}

--- a/collections/Customers.ts
+++ b/collections/Customers.ts
@@ -16,6 +16,13 @@ export const Customers: CollectionConfig = {
 		defaultColumns: ["email", "name", "createdAt"],
 		description:
 			"Customer accounts created via Google OAuth sign-in. Managed by NextAuth – do not create manually.",
+		components: {
+			edit: {
+				beforeDocumentControls: [
+					"@/components/admin/CreateOrderForCustomerButton",
+				],
+			},
+		},
 	},
 	access: {
 		// Only admins can read/update/delete via the Payload admin panel.

--- a/components/admin/AdminNavLinks.tsx
+++ b/components/admin/AdminNavLinks.tsx
@@ -29,6 +29,14 @@ export default function AdminNavLinks() {
 	return (
 		<>
 			<Link
+				href="/admin/create-order"
+				style={linkStyle}
+				onMouseEnter={handleMouseEnter}
+				onMouseLeave={handleMouseLeave}
+			>
+				➕ Create Order
+			</Link>
+			<Link
 				href="/admin/verify-payments"
 				style={linkStyle}
 				onMouseEnter={handleMouseEnter}

--- a/components/admin/CreateOrderForCustomerButton.tsx
+++ b/components/admin/CreateOrderForCustomerButton.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useDocumentInfo } from "@payloadcms/ui";
+import Link from "next/link";
+
+/**
+ * Payload admin button shown on a Customer's edit view. Deep-links the admin to
+ * the "Create Order for Customer" view with this customer pre-selected
+ * (?customerId=<id>), so they can go straight to uploading the customer's files
+ * and putting the order into the payment stage.
+ */
+export const CreateOrderForCustomerButton: React.FC = () => {
+	const { id } = useDocumentInfo();
+
+	// No id means this is the "create new customer" screen — nothing to link to.
+	if (!id) return null;
+
+	const href = `/admin/create-order?customerId=${encodeURIComponent(String(id))}`;
+
+	return (
+		<div
+			style={{
+				padding: "16px",
+				marginBottom: "16px",
+				background: "#e3f2fd",
+				borderRadius: "8px",
+				border: "2px solid #1976d2",
+			}}
+		>
+			<h4 style={{ margin: "0 0 8px", color: "#1565c0" }}>
+				🖨️ Create an order for this customer
+			</h4>
+			<p style={{ margin: "0 0 12px", fontSize: "14px", color: "#666" }}>
+				Manually upload this customer's files and put them into the payment
+				stage — useful when they couldn't upload on the site themselves.
+			</p>
+			<Link
+				href={href}
+				style={{
+					display: "inline-block",
+					background: "#1976d2",
+					color: "#fff",
+					padding: "10px 24px",
+					borderRadius: "6px",
+					fontSize: "14px",
+					fontWeight: 600,
+					textDecoration: "none",
+				}}
+			>
+				➕ Create order for this customer
+			</Link>
+		</div>
+	);
+};
+
+export default CreateOrderForCustomerButton;

--- a/components/admin/CreateOrderView.tsx
+++ b/components/admin/CreateOrderView.tsx
@@ -77,6 +77,7 @@ function CreateOrderViewInner() {
 	const [progressLabel, setProgressLabel] = useState<string | null>(null);
 	const [submitError, setSubmitError] = useState<string | null>(null);
 	const [createdOrder, setCreatedOrder] = useState<CreatedOrder | null>(null);
+	const [copied, setCopied] = useState(false);
 
 	const handleSearch = useCallback(async () => {
 		setSearching(true);
@@ -229,7 +230,30 @@ function CreateOrderViewInner() {
 	const resetForNewOrder = useCallback(() => {
 		setCreatedOrder(null);
 		setSubmitError(null);
+		setCopied(false);
 	}, []);
+
+	// Customer-facing link that resumes the order straight into the payment
+	// step (see statusToStep in OrderContainer: DRAFT → PAYMENT). The admin can
+	// copy this and send it to the customer so they land directly on payment.
+	const resumeUrl = useMemo(() => {
+		if (!createdOrder) return "";
+		const origin = typeof window !== "undefined" ? window.location.origin : "";
+		return `${origin}/order?resume=${createdOrder.id}`;
+	}, [createdOrder]);
+
+	const handleCopyResumeUrl = useCallback(async () => {
+		if (!resumeUrl) return;
+		try {
+			await navigator.clipboard.writeText(resumeUrl);
+			setCopied(true);
+			setTimeout(() => setCopied(false), 2000);
+		} catch {
+			// Clipboard API can fail (e.g. insecure context) — leave the link
+			// visible so the admin can select and copy it manually.
+			setCopied(false);
+		}
+	}, [resumeUrl]);
 
 	return (
 		<div style={{ padding: "2rem", maxWidth: 860, margin: "0 auto" }}>
@@ -471,6 +495,45 @@ function CreateOrderViewInner() {
 						Total:{" "}
 						<strong>{formatCurrency(createdOrder.pricing?.total)}</strong>
 					</p>
+					<div style={{ margin: "0.75rem 0" }}>
+						<label
+							htmlFor="resume-link"
+							style={{
+								display: "block",
+								fontWeight: 600,
+								marginBottom: "0.25rem",
+							}}
+						>
+							Send this link to the customer to pay:
+						</label>
+						<div style={{ display: "flex", gap: "0.5rem" }}>
+							<input
+								id="resume-link"
+								type="text"
+								readOnly
+								value={resumeUrl}
+								onFocus={(e) => e.target.select()}
+								style={{
+									flex: 1,
+									padding: "0.5rem",
+									fontFamily: "monospace",
+								}}
+							/>
+							<button type="button" onClick={handleCopyResumeUrl}>
+								{copied ? "Copied!" : "Copy link"}
+							</button>
+						</div>
+						<p
+							style={{
+								margin: "0.25rem 0 0",
+								color: "var(--theme-elevation-600)",
+								fontSize: "0.85rem",
+							}}
+						>
+							Opens the order directly on the payment step (customer must sign
+							in). It's also available under “My Orders”.
+						</p>
+					</div>
 					<button type="button" onClick={resetForNewOrder}>
 						Create another order
 					</button>

--- a/components/admin/CreateOrderView.tsx
+++ b/components/admin/CreateOrderView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
 	type FileToUpload,
 	type PresignedUpload,
@@ -78,6 +78,48 @@ function CreateOrderViewInner() {
 	const [submitError, setSubmitError] = useState<string | null>(null);
 	const [createdOrder, setCreatedOrder] = useState<CreatedOrder | null>(null);
 	const [copied, setCopied] = useState(false);
+	const [preselectError, setPreselectError] = useState<string | null>(null);
+
+	// Deep-link support: when the admin arrives with ?customerId=<id> (e.g. from
+	// a "Create order" link on a customer's admin record), fetch that customer
+	// and pre-select them so the admin can jump straight to adding files.
+	useEffect(() => {
+		if (typeof window === "undefined") return;
+		const customerId = new URLSearchParams(window.location.search)
+			.get("customerId")
+			?.trim();
+		if (!customerId) return;
+
+		let cancelled = false;
+		(async () => {
+			try {
+				const res = await fetch(
+					`/api/admin/customers?id=${encodeURIComponent(customerId)}`,
+				);
+				if (!res.ok) {
+					const data = (await res.json().catch(() => ({}))) as {
+						error?: string;
+					};
+					throw new Error(
+						data.error || `Could not load customer (HTTP ${res.status}).`,
+					);
+				}
+				const data = (await res.json()) as { customers?: Customer[] };
+				const customer = data.customers?.[0];
+				if (!cancelled && customer) setSelectedCustomer(customer);
+			} catch (err) {
+				if (!cancelled) {
+					setPreselectError(
+						err instanceof Error ? err.message : "Could not load customer.",
+					);
+				}
+			}
+		})();
+
+		return () => {
+			cancelled = true;
+		};
+	}, []);
 
 	const handleSearch = useCallback(async () => {
 		setSearching(true);
@@ -267,6 +309,11 @@ function CreateOrderViewInner() {
 			{/* ---- Step 1: Customer ---- */}
 			<section style={{ marginTop: "1.5rem" }}>
 				<h2 style={{ fontSize: "1.1rem" }}>1. Select customer</h2>
+				{preselectError && (
+					<p style={{ color: "var(--theme-error-500, #c00)" }}>
+						{preselectError} Search for the customer below instead.
+					</p>
+				)}
 				{selectedCustomer ? (
 					<div
 						style={{

--- a/components/admin/CreateOrderView.tsx
+++ b/components/admin/CreateOrderView.tsx
@@ -1,0 +1,495 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import {
+	type FileToUpload,
+	type PresignedUpload,
+	uploadFilesWithProgress,
+} from "../../lib/uploadClient";
+import AdminQueryProvider from "./AdminQueryProvider";
+import BackToDashboard from "./BackToDashboard";
+
+/**
+ * Admin custom view: manually create an order on behalf of a customer.
+ *
+ * Use case: a customer couldn't upload their files on the site, so the admin
+ * uploads the PDFs for them and finalises a DRAFT order owned by that customer.
+ * The customer can then resume the order from "My Orders" and go through the
+ * normal timeslot selection + payment flow — this view simply puts them into
+ * the payment stage.
+ *
+ * Flow:
+ *  1. Search for and select the target customer (GET /api/admin/customers).
+ *  2. Add one or more PDFs, each with copies + colour mode.
+ *  3. Presign + upload directly to R2 (POST /api/admin/orders/staging-urls),
+ *     scoped to the target customer's staging prefix.
+ *  4. Finalise the DRAFT order (POST /api/admin/orders), which verifies the
+ *     staged files server-side, counts pages, prices the order and creates it.
+ */
+
+interface Customer {
+	id: string;
+	email: string;
+	name: string;
+}
+
+interface StagedFileEntry {
+	/** Stable id for React keys. */
+	id: string;
+	file: File;
+	copies: number;
+	colorMode: "BW" | "COLOR";
+}
+
+interface CreatedOrder {
+	id: string;
+	orderNumber?: string;
+	status: string;
+	pricing?: {
+		subtotal?: number;
+		discount?: number;
+		total?: number;
+	};
+}
+
+const MAX_COPIES = 1000;
+
+function formatCurrency(cents: number | undefined): string {
+	if (typeof cents !== "number" || !Number.isFinite(cents)) return "—";
+	return `$${(cents / 100).toFixed(2)}`;
+}
+
+function CreateOrderViewInner() {
+	// ---- Customer search state ----
+	const [searchTerm, setSearchTerm] = useState("");
+	const [searchResults, setSearchResults] = useState<Customer[]>([]);
+	const [searching, setSearching] = useState(false);
+	const [searchError, setSearchError] = useState<string | null>(null);
+	const [selectedCustomer, setSelectedCustomer] = useState<Customer | null>(
+		null,
+	);
+
+	// ---- File state ----
+	const [stagedFiles, setStagedFiles] = useState<StagedFileEntry[]>([]);
+
+	// ---- Submission state ----
+	const [submitting, setSubmitting] = useState(false);
+	const [progressLabel, setProgressLabel] = useState<string | null>(null);
+	const [submitError, setSubmitError] = useState<string | null>(null);
+	const [createdOrder, setCreatedOrder] = useState<CreatedOrder | null>(null);
+
+	const handleSearch = useCallback(async () => {
+		setSearching(true);
+		setSearchError(null);
+		try {
+			const res = await fetch(
+				`/api/admin/customers?search=${encodeURIComponent(searchTerm)}&limit=20`,
+			);
+			if (!res.ok) {
+				const data = (await res.json().catch(() => ({}))) as {
+					error?: string;
+				};
+				throw new Error(data.error || `Search failed (HTTP ${res.status}).`);
+			}
+			const data = (await res.json()) as { customers?: Customer[] };
+			setSearchResults(data.customers ?? []);
+		} catch (err) {
+			setSearchError(err instanceof Error ? err.message : "Search failed.");
+			setSearchResults([]);
+		} finally {
+			setSearching(false);
+		}
+	}, [searchTerm]);
+
+	const handleAddFiles = useCallback((fileList: FileList | null) => {
+		if (!fileList || fileList.length === 0) return;
+		const additions: StagedFileEntry[] = Array.from(fileList).map((file) => ({
+			id: `${file.name}-${file.size}-${Date.now()}-${Math.random()
+				.toString(36)
+				.slice(2)}`,
+			file,
+			copies: 1,
+			colorMode: "BW",
+		}));
+		setStagedFiles((prev) => [...prev, ...additions]);
+	}, []);
+
+	const updateEntry = useCallback(
+		(id: string, patch: Partial<Omit<StagedFileEntry, "id" | "file">>) => {
+			setStagedFiles((prev) =>
+				prev.map((entry) => (entry.id === id ? { ...entry, ...patch } : entry)),
+			);
+		},
+		[],
+	);
+
+	const removeEntry = useCallback((id: string) => {
+		setStagedFiles((prev) => prev.filter((entry) => entry.id !== id));
+	}, []);
+
+	const canSubmit = useMemo(
+		() => !!selectedCustomer && stagedFiles.length > 0 && !submitting,
+		[selectedCustomer, stagedFiles.length, submitting],
+	);
+
+	const handleSubmit = useCallback(async () => {
+		if (!selectedCustomer || stagedFiles.length === 0) return;
+		setSubmitting(true);
+		setSubmitError(null);
+		setCreatedOrder(null);
+		setProgressLabel("Requesting upload URLs…");
+
+		try {
+			// Step 1: request customer-scoped presigned upload URLs.
+			const presignRes = await fetch("/api/admin/orders/staging-urls", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					customerId: selectedCustomer.id,
+					files: stagedFiles.map((e) => ({
+						name: e.file.name,
+						size: e.file.size,
+						type: e.file.type || "application/pdf",
+					})),
+				}),
+			});
+			if (!presignRes.ok) {
+				const data = (await presignRes.json().catch(() => ({}))) as {
+					error?: string;
+				};
+				throw new Error(
+					data.error || `Failed to start upload (HTTP ${presignRes.status}).`,
+				);
+			}
+			const presignData = (await presignRes.json()) as {
+				uploads?: PresignedUpload[];
+			};
+			const uploads = presignData.uploads ?? [];
+			if (uploads.length !== stagedFiles.length) {
+				throw new Error(
+					"Server returned an invalid set of upload URLs. Please try again.",
+				);
+			}
+
+			// Step 2: upload each file directly to R2 with progress.
+			const filesToUpload: FileToUpload[] = stagedFiles.map((e) => ({
+				file: e.file,
+				displayName: e.file.name,
+			}));
+			await uploadFilesWithProgress({
+				files: filesToUpload,
+				uploads,
+				onProgress: ({ displayName, percent }) =>
+					setProgressLabel(`Uploading ${displayName} — ${percent}%`),
+			});
+
+			// Step 3: finalise the DRAFT order. `uploads` preserves input order,
+			// so stagingKey[i] corresponds to stagedFiles[i].
+			setProgressLabel("Finalising order…");
+			const finaliseRes = await fetch("/api/admin/orders", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					customerId: selectedCustomer.id,
+					files: stagedFiles.map((e, i) => ({
+						stagingKey: uploads[i].stagingKey,
+						fileName: e.file.name,
+						copies: e.copies,
+						colorMode: e.colorMode,
+					})),
+				}),
+			});
+			if (!finaliseRes.ok) {
+				const data = (await finaliseRes.json().catch(() => ({}))) as {
+					error?: string;
+				};
+				throw new Error(
+					data.error || `Failed to create order (HTTP ${finaliseRes.status}).`,
+				);
+			}
+			const finaliseData = (await finaliseRes.json()) as {
+				order?: CreatedOrder;
+			};
+			if (!finaliseData.order) {
+				throw new Error("Order was created but the response was malformed.");
+			}
+
+			setCreatedOrder(finaliseData.order);
+			setStagedFiles([]);
+		} catch (err) {
+			setSubmitError(
+				err instanceof Error ? err.message : "Failed to create order.",
+			);
+		} finally {
+			setSubmitting(false);
+			setProgressLabel(null);
+		}
+	}, [selectedCustomer, stagedFiles]);
+
+	const resetForNewOrder = useCallback(() => {
+		setCreatedOrder(null);
+		setSubmitError(null);
+	}, []);
+
+	return (
+		<div style={{ padding: "2rem", maxWidth: 860, margin: "0 auto" }}>
+			<BackToDashboard />
+			<h1 style={{ marginBottom: "0.25rem" }}>Create Order for Customer</h1>
+			<p style={{ color: "var(--theme-elevation-600)", marginTop: 0 }}>
+				Manually upload a customer's files and put them into the payment stage.
+				The customer can then pick a pickup slot and pay from “My Orders”.
+			</p>
+
+			{/* ---- Step 1: Customer ---- */}
+			<section style={{ marginTop: "1.5rem" }}>
+				<h2 style={{ fontSize: "1.1rem" }}>1. Select customer</h2>
+				{selectedCustomer ? (
+					<div
+						style={{
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "space-between",
+							gap: "1rem",
+							padding: "0.75rem 1rem",
+							border: "1px solid var(--theme-elevation-150)",
+							borderRadius: 6,
+						}}
+					>
+						<div>
+							<strong>{selectedCustomer.name || "(no name)"}</strong>
+							<div style={{ color: "var(--theme-elevation-600)" }}>
+								{selectedCustomer.email}
+							</div>
+						</div>
+						<button
+							type="button"
+							onClick={() => setSelectedCustomer(null)}
+							disabled={submitting}
+						>
+							Change
+						</button>
+					</div>
+				) : (
+					<>
+						<div style={{ display: "flex", gap: "0.5rem" }}>
+							<input
+								type="text"
+								value={searchTerm}
+								placeholder="Search by name or email…"
+								onChange={(e) => setSearchTerm(e.target.value)}
+								onKeyDown={(e) => {
+									if (e.key === "Enter") handleSearch();
+								}}
+								style={{ flex: 1, padding: "0.5rem" }}
+							/>
+							<button type="button" onClick={handleSearch} disabled={searching}>
+								{searching ? "Searching…" : "Search"}
+							</button>
+						</div>
+						{searchError && (
+							<p style={{ color: "var(--theme-error-500, #c00)" }}>
+								{searchError}
+							</p>
+						)}
+						{searchResults.length > 0 && (
+							<ul
+								style={{
+									listStyle: "none",
+									padding: 0,
+									marginTop: "0.75rem",
+									border: "1px solid var(--theme-elevation-150)",
+									borderRadius: 6,
+								}}
+							>
+								{searchResults.map((c) => (
+									<li
+										key={c.id}
+										style={{
+											borderBottom: "1px solid var(--theme-elevation-100)",
+										}}
+									>
+										<button
+											type="button"
+											onClick={() => {
+												setSelectedCustomer(c);
+												setSearchResults([]);
+											}}
+											style={{
+												display: "block",
+												width: "100%",
+												textAlign: "left",
+												padding: "0.6rem 1rem",
+												background: "transparent",
+												border: "none",
+												cursor: "pointer",
+											}}
+										>
+											<strong>{c.name || "(no name)"}</strong>
+											<span
+												style={{
+													color: "var(--theme-elevation-600)",
+													marginLeft: 8,
+												}}
+											>
+												{c.email}
+											</span>
+										</button>
+									</li>
+								))}
+							</ul>
+						)}
+					</>
+				)}
+			</section>
+
+			{/* ---- Step 2: Files ---- */}
+			<section style={{ marginTop: "2rem" }}>
+				<h2 style={{ fontSize: "1.1rem" }}>2. Add files</h2>
+				<input
+					type="file"
+					accept="application/pdf"
+					multiple
+					disabled={submitting}
+					onChange={(e) => {
+						handleAddFiles(e.target.files);
+						e.target.value = "";
+					}}
+				/>
+				{stagedFiles.length > 0 && (
+					<table
+						style={{
+							width: "100%",
+							marginTop: "1rem",
+							borderCollapse: "collapse",
+						}}
+					>
+						<thead>
+							<tr style={{ textAlign: "left" }}>
+								<th style={{ padding: "0.4rem" }}>File</th>
+								<th style={{ padding: "0.4rem", width: 110 }}>Copies</th>
+								<th style={{ padding: "0.4rem", width: 130 }}>Colour</th>
+								<th style={{ padding: "0.4rem", width: 60 }} />
+							</tr>
+						</thead>
+						<tbody>
+							{stagedFiles.map((entry) => (
+								<tr
+									key={entry.id}
+									style={{ borderTop: "1px solid var(--theme-elevation-100)" }}
+								>
+									<td style={{ padding: "0.4rem" }}>{entry.file.name}</td>
+									<td style={{ padding: "0.4rem" }}>
+										<input
+											type="number"
+											min={1}
+											max={MAX_COPIES}
+											value={entry.copies}
+											disabled={submitting}
+											onChange={(e) => {
+												const n = Number.parseInt(e.target.value, 10);
+												updateEntry(entry.id, {
+													copies: Number.isFinite(n)
+														? Math.min(Math.max(n, 1), MAX_COPIES)
+														: 1,
+												});
+											}}
+											style={{ width: 80, padding: "0.3rem" }}
+										/>
+									</td>
+									<td style={{ padding: "0.4rem" }}>
+										<select
+											value={entry.colorMode}
+											disabled={submitting}
+											onChange={(e) =>
+												updateEntry(entry.id, {
+													colorMode: e.target.value as "BW" | "COLOR",
+												})
+											}
+											style={{ padding: "0.3rem" }}
+										>
+											<option value="BW">B &amp; W</option>
+											<option value="COLOR">Colour</option>
+										</select>
+									</td>
+									<td style={{ padding: "0.4rem" }}>
+										<button
+											type="button"
+											onClick={() => removeEntry(entry.id)}
+											disabled={submitting}
+										>
+											✕
+										</button>
+									</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				)}
+			</section>
+
+			{/* ---- Step 3: Submit ---- */}
+			<section style={{ marginTop: "2rem" }}>
+				<button
+					type="button"
+					onClick={handleSubmit}
+					disabled={!canSubmit}
+					style={{
+						padding: "0.6rem 1.4rem",
+						fontWeight: 600,
+						cursor: canSubmit ? "pointer" : "not-allowed",
+					}}
+				>
+					{submitting ? "Creating…" : "Create draft order"}
+				</button>
+				{progressLabel && (
+					<p style={{ color: "var(--theme-elevation-600)" }}>{progressLabel}</p>
+				)}
+				{submitError && (
+					<p style={{ color: "var(--theme-error-500, #c00)" }}>{submitError}</p>
+				)}
+			</section>
+
+			{/* ---- Success ---- */}
+			{createdOrder && (
+				<section
+					style={{
+						marginTop: "2rem",
+						padding: "1rem 1.25rem",
+						border: "1px solid var(--theme-success-500, #2e7d32)",
+						borderRadius: 6,
+					}}
+				>
+					<h2 style={{ fontSize: "1.1rem", marginTop: 0 }}>
+						✅ Draft order created
+					</h2>
+					<p style={{ margin: "0.25rem 0" }}>
+						Order <strong>{createdOrder.orderNumber || createdOrder.id}</strong>{" "}
+						is now a {createdOrder.status}. The customer can select a pickup
+						slot and pay from “My Orders”.
+					</p>
+					<p style={{ margin: "0.25rem 0" }}>
+						Total:{" "}
+						<strong>{formatCurrency(createdOrder.pricing?.total)}</strong>
+					</p>
+					<button type="button" onClick={resetForNewOrder}>
+						Create another order
+					</button>
+				</section>
+			)}
+		</div>
+	);
+}
+
+/**
+ * Default export wraps the view in `AdminQueryProvider` so it matches the
+ * admin (App Router) provider pattern used by other custom views, even though
+ * this view currently uses plain fetch — this keeps it consistent and ready
+ * for future React Query migration.
+ */
+export default function CreateOrderView() {
+	return (
+		<AdminQueryProvider>
+			<CreateOrderViewInner />
+		</AdminQueryProvider>
+	);
+}

--- a/payload.config.ts
+++ b/payload.config.ts
@@ -100,6 +100,13 @@ export default (async () =>
 			},
 			components: {
 				views: {
+					createOrder: {
+						Component: "@/components/admin/CreateOrderView",
+						path: "/create-order",
+						meta: {
+							title: "Create Order for Customer",
+						},
+					},
 					ordersByTimeslot: {
 						Component: "@/components/admin/OrdersByTimeslotView",
 						path: "/orders-by-timeslot",


### PR DESCRIPTION
## Summary

Adds an admin-facing "Create Order for Customer" flow, letting admins manually build a customer's DRAFT order from their uploaded files and hand it off for payment.

## Changes

- **New admin view** — Built and registered a "Create Order for Customer" admin view (`components/admin/CreateOrderView.tsx`) that ties existing admin APIs together into a working UI for manually creating a customer's DRAFT order from their files.
- **Deep-link entry point** — Added a "Create Order" button on a customer's record (`components/admin/CreateOrderForCustomerButton.tsx`) plus `?customerId=` pre-selection, so admins can start the manual-order flow directly from a user.
- **Customer resume link** — The Create Order success screen now shows a copyable customer resume link (`/order?resume=<id>`), and the full end-to-end admin-created-order flow into the payment stage was verified.
- **Supporting APIs** — New/updated admin routes:
  - `app/api/admin/customers/route.ts`
  - `app/api/admin/orders/route.ts`
  - `app/api/admin/orders/staging-urls/route.ts`
- **Wiring** — Updates to `payload.config.ts`, `app/(payload)/admin/importMap.js`, `collections/Customers.ts`, and `components/admin/AdminNavLinks.tsx` to register the view and nav entry.

## Testing

- Verified the full end-to-end admin-created-order flow into the payment stage.
