### PR TITLE
feat(timeslots): confirm-and-message flow for timeslot deletion

### DIFF
--- a/app/(payload)/admin/importMap.js
+++ b/app/(payload)/admin/importMap.js
@@ -33,6 +33,7 @@ import { default as default_createorderview01234567890abcdef } from '@/component
 import { default as default_ae6d727f69bea18ad23ef405314d6459 } from '@/components/admin/PendingVerificationView'
 import { default as default_357e94cb16882b41b62ce8427705d759 } from '@/components/admin/NotifyTimeslotsView'
 import { default as default_f0bf1af8c7fcbee7729125193a4368fe } from '@/components/admin/ScheduleCalendarView'
+import { default as default_deletetimeslotbtn0123456789abcdef } from '@/components/admin/DeleteTimeslotButton'
 import { CollectionCards as CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
 
 /** @type import('payload').ImportMap */
@@ -72,5 +73,6 @@ export const importMap = {
   "@/components/admin/PendingVerificationView#default": default_ae6d727f69bea18ad23ef405314d6459,
   "@/components/admin/NotifyTimeslotsView#default": default_357e94cb16882b41b62ce8427705d759,
   "@/components/admin/ScheduleCalendarView#default": default_f0bf1af8c7fcbee7729125193a4368fe,
+  "@/components/admin/DeleteTimeslotButton#default": default_deletetimeslotbtn0123456789abcdef,
   "@payloadcms/next/rsc#CollectionCards": CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1
 }

--- a/app/api/admin/timeslots/[id]/delete/route.ts
+++ b/app/api/admin/timeslots/[id]/delete/route.ts
@@ -1,0 +1,200 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { sendTimeslotDeletedEmail } from "../../../../../../lib/email";
+import { getPayloadClient } from "../../../../../../lib/payload";
+
+export const runtime = "nodejs";
+// Notifying many customers by email can take a little while.
+export const maxDuration = 60;
+
+interface OrderFileShape {
+	fileName: string;
+	pageCount: number;
+	copies: number;
+	colorMode: string;
+	paperSize: string;
+	doubleSided: boolean;
+}
+
+interface PricingShape {
+	subtotal: number;
+	tax: number;
+	total: number;
+}
+
+/**
+ * GET /api/admin/timeslots/[id]/delete
+ *
+ * Admin-only preview endpoint. Returns how many orders are booked into this
+ * timeslot so the delete confirmation UI can tell the admin how many customers
+ * will be notified, plus a human-readable label for the slot.
+ */
+export async function GET(
+	request: NextRequest,
+	{ params }: { params: Promise<{ id: string }> },
+) {
+	try {
+		const { id } = await params;
+		const payload = await getPayloadClient();
+
+		const { user } = await payload.auth({ headers: request.headers });
+		if (!user) {
+			return NextResponse.json(
+				{ error: "Admin authentication required." },
+				{ status: 401 },
+			);
+		}
+
+		const timeslot = await payload
+			.findByID({ collection: "timeslots", id })
+			.catch(() => null);
+
+		if (!timeslot) {
+			return NextResponse.json(
+				{ error: "Timeslot not found." },
+				{ status: 404 },
+			);
+		}
+
+		const { totalDocs } = await payload.find({
+			collection: "orders",
+			where: { pickupTimeslot: { equals: id } },
+			limit: 0,
+			depth: 0,
+		});
+
+		return NextResponse.json({
+			affectedOrders: totalDocs,
+			label:
+				(timeslot as { label?: string }).label ||
+				`${(timeslot as { date?: string }).date ?? ""} ${
+					(timeslot as { startTime?: string }).startTime ?? ""
+				}`.trim(),
+		});
+	} catch (error) {
+		console.error("Error loading timeslot delete preview:", error);
+		return NextResponse.json(
+			{ error: "Failed to load timeslot details." },
+			{ status: 500 },
+		);
+	}
+}
+
+/**
+ * POST /api/admin/timeslots/[id]/delete
+ *
+ * Admin-only endpoint that deletes a timeslot and notifies every customer with
+ * an order booked into it. The admin supplies a personalised message (shown in
+ * the email as "A note from us"). Each affected order has its pickupTimeslot
+ * reference cleared so the customer can select a new slot.
+ *
+ * Body: `{ "message"?: string }`
+ */
+export async function POST(
+	request: NextRequest,
+	{ params }: { params: Promise<{ id: string }> },
+) {
+	try {
+		const { id } = await params;
+		const payload = await getPayloadClient();
+
+		const { user } = await payload.auth({ headers: request.headers });
+		if (!user) {
+			return NextResponse.json(
+				{ error: "Admin authentication required." },
+				{ status: 401 },
+			);
+		}
+
+		const body = (await request.json().catch(() => ({}))) as {
+			message?: string;
+		};
+		const customMessage = body.message?.trim() || undefined;
+
+		// Confirm the timeslot exists before doing any work.
+		const timeslot = await payload
+			.findByID({ collection: "timeslots", id })
+			.catch(() => null);
+		if (!timeslot) {
+			return NextResponse.json(
+				{ error: "Timeslot not found." },
+				{ status: 404 },
+			);
+		}
+
+		// Find all orders booked into this timeslot (populate the customer).
+		const { docs: orders } = await payload.find({
+			collection: "orders",
+			where: { pickupTimeslot: { equals: id } },
+			depth: 1,
+			limit: 0,
+		});
+
+		let notified = 0;
+
+		// Clear each order's reference and email the customer.
+		const results = await Promise.allSettled(
+			orders.map(async (order) => {
+				try {
+					await payload.update({
+						collection: "orders",
+						id: order.id,
+						data: { pickupTimeslot: null },
+					});
+				} catch (error) {
+					console.error(
+						`[Timeslots] Failed to clear pickupTimeslot on order ${order.orderNumber}:`,
+						error,
+					);
+				}
+
+				const customer = order.customer as {
+					email?: string;
+					name?: string;
+				} | null;
+				if (!customer?.email) return;
+
+				await sendTimeslotDeletedEmail({
+					to: customer.email,
+					customerName: customer.name || "Customer",
+					orderNumber: order.orderNumber,
+					files: (order.files || []) as OrderFileShape[],
+					pricing: order.pricing as PricingShape | undefined,
+					customMessage,
+				});
+				notified += 1;
+			}),
+		);
+
+		for (const result of results) {
+			if (result.status === "rejected") {
+				console.error(
+					"[Timeslots] Failed to notify a customer of deletion:",
+					result.reason,
+				);
+			}
+		}
+
+		// Finally, delete the timeslot itself.
+		await payload.delete({ collection: "timeslots", id });
+
+		console.log(
+			`[Timeslots] Deleted timeslot ${id}; notified ${notified}/${orders.length} order(s).`,
+		);
+
+		return NextResponse.json({
+			success: true,
+			deleted: true,
+			affectedOrders: orders.length,
+			notified,
+		});
+	} catch (error) {
+		console.error("Error deleting timeslot:", error);
+		return NextResponse.json(
+			{
+				error:
+					error instanceof Error ? error.message : "Failed to delete timeslot.",
+			},
+			{ status: 500 },
+		);
+	}
+}

--- a/collections/Timeslots.ts
+++ b/collections/Timeslots.ts
@@ -1,12 +1,5 @@
-import type {
-	CollectionAfterChangeHook,
-	CollectionAfterDeleteHook,
-	CollectionConfig,
-} from "payload";
-import {
-	sendTimeslotChangedEmail,
-	sendTimeslotDeletedEmail,
-} from "../lib/email";
+import type { CollectionAfterChangeHook, CollectionConfig } from "payload";
+import { sendTimeslotChangedEmail } from "../lib/email";
 import { getPayloadClient } from "../lib/payload";
 
 /**
@@ -104,81 +97,6 @@ const notifyOnTimeslotChange: CollectionAfterChangeHook = async ({
 	return doc;
 };
 
-// ── afterDelete hook: notify customers when a booked timeslot is deleted ──
-const notifyOnTimeslotDelete: CollectionAfterDeleteHook = async ({
-	id,
-	req,
-}) => {
-	// Fire-and-forget so the admin UI isn't blocked
-	void (async () => {
-		try {
-			const payload = req.payload ?? (await getPayloadClient());
-
-			// Find all orders that still reference the deleted timeslot
-			const { docs: orders } = await payload.find({
-				collection: "orders",
-				where: { pickupTimeslot: { equals: id } },
-				depth: 1, // populate the customer relationship
-				limit: 0, // no limit — fetch all
-			});
-
-			if (orders.length === 0) return;
-
-			// Clear the dangling timeslot reference and email each customer
-			await Promise.allSettled(
-				orders.map(async (order) => {
-					// Remove the reference so the customer can re-select a slot
-					try {
-						await payload.update({
-							collection: "orders",
-							id: order.id,
-							data: { pickupTimeslot: null },
-						});
-					} catch (error) {
-						console.error(
-							`[Timeslots] Failed to clear pickupTimeslot on order ${order.orderNumber}:`,
-							error,
-						);
-					}
-
-					const customer = order.customer as {
-						email?: string;
-						name?: string;
-					} | null;
-
-					if (!customer?.email) return;
-
-					await sendTimeslotDeletedEmail({
-						to: customer.email,
-						customerName: customer.name || "Customer",
-						orderNumber: order.orderNumber,
-						files: (order.files || []) as {
-							fileName: string;
-							pageCount: number;
-							copies: number;
-							colorMode: string;
-							paperSize: string;
-							doubleSided: boolean;
-						}[],
-						pricing: order.pricing as
-							| { subtotal: number; tax: number; total: number }
-							| undefined,
-					});
-				}),
-			);
-
-			console.log(
-				`[Timeslots] Notified ${orders.length} order(s) about deleted timeslot ${id}`,
-			);
-		} catch (error) {
-			console.error(
-				`[Timeslots] Failed to send timeslot-deleted emails for ${id}:`,
-				error,
-			);
-		}
-	})();
-};
-
 export const Timeslots: CollectionConfig = {
 	slug: "timeslots",
 	admin: {
@@ -194,6 +112,11 @@ export const Timeslots: CollectionConfig = {
 		],
 		description:
 			"Pickup time windows. Created automatically from Schedules or manually for one-off slots.",
+		components: {
+			edit: {
+				beforeDocumentControls: ["@/components/admin/DeleteTimeslotButton"],
+			},
+		},
 	},
 	access: {
 		// Public read so customers can fetch available timeslots
@@ -205,7 +128,6 @@ export const Timeslots: CollectionConfig = {
 	},
 	hooks: {
 		afterChange: [notifyOnTimeslotChange],
-		afterDelete: [notifyOnTimeslotDelete],
 	},
 	fields: [
 		{

--- a/components/admin/DeleteTimeslotButton.tsx
+++ b/components/admin/DeleteTimeslotButton.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { useDocumentInfo } from "@payloadcms/ui";
+import { useCallback, useEffect, useState } from "react";
+
+interface TimeslotDocumentData {
+	label?: string;
+	date?: string;
+	startTime?: string;
+	endTime?: string;
+}
+
+/** Default message pre-filled into the textarea; the admin can edit or clear it. */
+function buildDefaultMessage(slot: TimeslotDocumentData): string {
+	const when = [slot.date, slot.startTime && `at ${slot.startTime}`]
+		.filter(Boolean)
+		.join(" ");
+	const slotText = when ? ` (${when})` : "";
+	return [
+		`We're really sorry, but we've had to remove the pickup slot you booked${slotText}.`,
+		"Please head to your orders page to choose a new pickup time that works for you. Thanks so much for your patience and understanding.",
+	].join("\n\n");
+}
+
+/**
+ * Payload admin custom component shown on the Timeslot edit view.
+ *
+ * Replaces the generic "delete" flow with a confirmation that lets the admin
+ * write a personalised message. On confirm, it deletes the timeslot and emails
+ * every customer booked into it (clearing their pickup selection so they can
+ * re-book).
+ */
+export const DeleteTimeslotButton: React.FC = () => {
+	const { id, initialData } = useDocumentInfo();
+	const slot = (initialData as TimeslotDocumentData) || {};
+
+	const [open, setOpen] = useState(false);
+	const [message, setMessage] = useState("");
+	const [affected, setAffected] = useState<number | null>(null);
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [success, setSuccess] = useState<string | null>(null);
+
+	// When the modal opens, seed the default message and fetch how many orders
+	// are booked into this slot so the admin knows how many will be notified.
+	useEffect(() => {
+		if (!open || !id) return;
+		setMessage(buildDefaultMessage(slot));
+		setAffected(null);
+		setError(null);
+
+		let cancelled = false;
+		(async () => {
+			try {
+				const res = await fetch(`/api/admin/timeslots/${id}/delete`);
+				if (!res.ok) return;
+				const data = (await res.json()) as { affectedOrders?: number };
+				if (!cancelled && typeof data.affectedOrders === "number") {
+					setAffected(data.affectedOrders);
+				}
+			} catch {
+				// Non-fatal: the count is informational only.
+			}
+		})();
+
+		return () => {
+			cancelled = true;
+		};
+	}, [open, id, slot]);
+
+	const handleDelete = useCallback(async () => {
+		if (!id) return;
+		setLoading(true);
+		setError(null);
+
+		try {
+			const res = await fetch(`/api/admin/timeslots/${id}/delete`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ message }),
+			});
+
+			const data = (await res.json()) as {
+				error?: string;
+				notified?: number;
+			};
+
+			if (!res.ok) {
+				throw new Error(data.error || "Failed to delete timeslot.");
+			}
+
+			setSuccess(
+				`Timeslot deleted. Notified ${data.notified ?? 0} customer(s). Redirecting…`,
+			);
+			// Send the admin back to the timeslots list.
+			setTimeout(() => {
+				window.location.href = "/admin/collections/timeslots";
+			}, 1200);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Unknown error.");
+			setLoading(false);
+		}
+	}, [id, message]);
+
+	// Only meaningful once the document has been created/saved.
+	if (!id) return null;
+
+	return (
+		<div style={{ marginBottom: 16 }}>
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				style={{
+					background: "#fff",
+					color: "#c62828",
+					border: "2px solid #c62828",
+					padding: "10px 20px",
+					borderRadius: 6,
+					fontSize: 14,
+					fontWeight: 600,
+					cursor: "pointer",
+				}}
+			>
+				🗑️ Delete timeslot & notify customers
+			</button>
+
+			{open && (
+				<div
+					style={{
+						position: "fixed",
+						inset: 0,
+						background: "rgba(0,0,0,0.5)",
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "center",
+						zIndex: 1000,
+						padding: 16,
+					}}
+				>
+					<div
+						style={{
+							background: "#fff",
+							borderRadius: 10,
+							padding: 24,
+							width: "100%",
+							maxWidth: 520,
+							boxShadow: "0 8px 32px rgba(0,0,0,0.25)",
+						}}
+					>
+						<h3 style={{ margin: "0 0 8px", color: "#1a1a2e" }}>
+							Delete this timeslot?
+						</h3>
+						<p style={{ margin: "0 0 12px", fontSize: 14, color: "#555" }}>
+							This permanently deletes the slot. Every customer booked into it
+							will be emailed and asked to choose a new pickup time.
+							{affected !== null && (
+								<>
+									{" "}
+									<strong>
+										{affected === 0
+											? "No orders are booked into this slot."
+											: `${affected} order(s) will be notified.`}
+									</strong>
+								</>
+							)}
+						</p>
+
+						<label
+							htmlFor="timeslot-delete-message"
+							style={{
+								display: "block",
+								fontSize: 13,
+								fontWeight: 600,
+								marginBottom: 6,
+								color: "#333",
+							}}
+						>
+							Message to customers (shown as "A note from us")
+						</label>
+						<textarea
+							id="timeslot-delete-message"
+							value={message}
+							onChange={(e) => setMessage(e.target.value)}
+							rows={6}
+							disabled={loading}
+							style={{
+								width: "100%",
+								boxSizing: "border-box",
+								padding: 10,
+								borderRadius: 6,
+								border: "1px solid #ccc",
+								fontSize: 14,
+								fontFamily: "inherit",
+								resize: "vertical",
+							}}
+						/>
+						<p style={{ margin: "6px 0 0", fontSize: 12, color: "#888" }}>
+							Leave blank to send only the standard apology.
+						</p>
+
+						{error && (
+							<p style={{ color: "#d32f2f", marginTop: 10, fontSize: 14 }}>
+								Error: {error}
+							</p>
+						)}
+						{success && (
+							<p style={{ color: "#2e7d32", marginTop: 10, fontSize: 14 }}>
+								{success}
+							</p>
+						)}
+
+						<div
+							style={{
+								display: "flex",
+								justifyContent: "flex-end",
+								gap: 8,
+								marginTop: 20,
+							}}
+						>
+							<button
+								type="button"
+								onClick={() => setOpen(false)}
+								disabled={loading}
+								style={{
+									background: "#f0f0f0",
+									color: "#333",
+									border: "none",
+									padding: "10px 20px",
+									borderRadius: 6,
+									fontSize: 14,
+									fontWeight: 600,
+									cursor: loading ? "not-allowed" : "pointer",
+								}}
+							>
+								Cancel
+							</button>
+							<button
+								type="button"
+								onClick={handleDelete}
+								disabled={loading || Boolean(success)}
+								style={{
+									background: loading ? "#ccc" : "#c62828",
+									color: "#fff",
+									border: "none",
+									padding: "10px 20px",
+									borderRadius: 6,
+									fontSize: 14,
+									fontWeight: 600,
+									cursor: loading ? "not-allowed" : "pointer",
+								}}
+							>
+								{loading ? "Deleting…" : "Delete & notify"}
+							</button>
+						</div>
+					</div>
+				</div>
+			)}
+		</div>
+	);
+};
+
+export default DeleteTimeslotButton;

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -291,8 +291,11 @@ export async function sendTimeslotDeletedEmail(params: {
 	orderNumber: string;
 	files: OrderFile[];
 	pricing: PricingInfo | undefined;
+	/** Optional personalised note from the admin, shown as "A note from us". */
+	customMessage?: string;
 }): Promise<void> {
-	const { to, customerName, orderNumber, files, pricing } = params;
+	const { to, customerName, orderNumber, files, pricing, customMessage } =
+		params;
 
 	const common = await buildCommonLocals(customerName);
 
@@ -301,6 +304,7 @@ export async function sendTimeslotDeletedEmail(params: {
 		orderNumber,
 		files: formatFilesForTemplate(files),
 		...formatPricingForTemplate(pricing),
+		customMessage: customMessage?.trim() || null,
 	});
 
 	await getTransporter().sendMail({

--- a/lib/templates/timeslotDeleted.pug
+++ b/lib/templates/timeslotDeleted.pug
@@ -19,6 +19,14 @@ html
 
         p Your order itself is safe and has not been affected. All you need to do is choose a new pickup time.
 
+        if customMessage
+          .section
+            .info-box
+              h3 A note from us
+              each line in customMessage.split("\n")
+                if line.trim()
+                  p= line
+
         .section
           .action-box
             h3 Select a New Pickup Slot


### PR DESCRIPTION
## Summary

Builds on the timeslot-deletion notification (#97) to give admins control over the message customers receive. Instead of an automatic, generic email on delete, deleting a timeslot now goes through a deliberate confirmation flow where the admin can write a personalised message.

## Behaviour

- On the Timeslot edit view, a **"Delete timeslot & notify customers"** button opens a confirmation modal.
- The modal shows **how many orders will be notified** and a textarea **pre-filled with an editable default apology** (mentioning the slot's date/time). The admin can tweak, replace, or clear it.
- On confirm, an admin API route:
  1. clears each affected order's `pickupTimeslot` so the customer can re-book,
  2. emails every booked customer (including the admin's note as an "A note from us" section),
  3. deletes the timeslot.
- The admin is redirected back to the timeslots list with a summary of how many customers were notified.

## Changes

- **`collections/Timeslots.ts`**: removed the automatic `afterDelete` notification hook; registered `DeleteTimeslotButton` via `admin.components.edit.beforeDocumentControls`.
- **`components/admin/DeleteTimeslotButton.tsx`** (new): client component with confirmation modal, affected-order count, and editable message box.
- **`app/api/admin/timeslots/[id]/delete/route.ts`** (new): admin-authenticated `GET` (affected count + label) and `POST` (clear references, notify, delete).
- **`lib/email.ts`**: `sendTimeslotDeletedEmail` now accepts an optional `customMessage`.
- **`lib/templates/timeslotDeleted.pug`**: renders the admin's message as a highlighted "A note from us" section (falls back to the standard apology when empty). No em dashes.
- **`app/(payload)/admin/importMap.js`**: registered the new component.

## Notes

- Because the auto `afterDelete` hook was removed, notification now happens **only** through this new button. Payload's default delete controls will not notify customers.

## Testing

- `tsc --noEmit` passes for changed files.
- `biome check` clean.
- Pug template renders correctly both with and without a custom message.