### PR TITLE
feat(admin): manage timeslot link + per-order download on orders-by-timeslot

### DIFF
--- a/app/api/admin/orders-by-timeslot/route.ts
+++ b/app/api/admin/orders-by-timeslot/route.ts
@@ -61,6 +61,28 @@ export async function GET(request: NextRequest) {
 			});
 		}
 
+		// Sort chronologically by date, then start/end time. The Payload query
+		// only sorts by date, so slots on the same day would otherwise appear in
+		// an arbitrary order. `date` is "YYYY-MM-DD" and the times are zero-padded
+		// "HH:MM", so lexicographic comparison is chronological.
+		const normaliseDate = (value: unknown): string =>
+			typeof value === "string"
+				? value.includes("T")
+					? value.split("T")[0]
+					: value
+				: "";
+		timeslots = [...timeslots].sort((a, b) => {
+			const dateCmp = normaliseDate(a.date).localeCompare(
+				normaliseDate(b.date),
+			);
+			if (dateCmp !== 0) return dateCmp;
+			const startCmp = String(a.startTime ?? "").localeCompare(
+				String(b.startTime ?? ""),
+			);
+			if (startCmp !== 0) return startCmp;
+			return String(a.endTime ?? "").localeCompare(String(b.endTime ?? ""));
+		});
+
 		const timeslotIds = timeslots.map((t) => String(t.id));
 
 		// ── 2. Fetch orders in two parallel queries ──────────────────────

--- a/components/admin/OrdersByTimeslotView.tsx
+++ b/components/admin/OrdersByTimeslotView.tsx
@@ -195,9 +195,15 @@ function OrdersByTimeslotViewInner() {
 		[getFileKey],
 	);
 
-	/** Download all files for all orders in a timeslot group sequentially */
+	/**
+	 * Open every downloadable file across the given orders in new tabs.
+	 *
+	 * Shared by the per-timeslot "Download All Files" button and the per-order
+	 * download button, so both behave identically (parallel presign, sequential
+	 * open with a small delay to dodge popup blockers).
+	 */
 	const downloadingRef = useRef(false);
-	const handleDownloadAllFiles = useCallback(
+	const downloadFilesForOrders = useCallback(
 		async (orders: OrderData[]) => {
 			if (downloadingRef.current) return;
 			downloadingRef.current = true;
@@ -263,6 +269,18 @@ function OrdersByTimeslotViewInner() {
 			}
 		},
 		[getFileKey],
+	);
+
+	/** Download all files across every order in a timeslot group. */
+	const handleDownloadAllFiles = useCallback(
+		(orders: OrderData[]) => downloadFilesForOrders(orders),
+		[downloadFilesForOrders],
+	);
+
+	/** Download all files for a single order. */
+	const handleDownloadOrderFiles = useCallback(
+		(order: OrderData) => downloadFilesForOrders([order]),
+		[downloadFilesForOrders],
 	);
 
 	return (
@@ -457,6 +475,23 @@ function OrdersByTimeslotViewInner() {
 								>
 									⬇ Download All Files
 								</button>
+								<a
+									href={`/admin/collections/timeslots/${timeslot.id}`}
+									title="Open this timeslot to edit or delete it"
+									style={{
+										padding: "3px 10px",
+										fontSize: "12px",
+										fontWeight: 600,
+										background: "rgba(255,255,255,0.15)",
+										color: "#fff",
+										border: "1px solid rgba(255,255,255,0.3)",
+										borderRadius: "4px",
+										cursor: "pointer",
+										textDecoration: "none",
+									}}
+								>
+									⚙ Manage Timeslot
+								</a>
 							</div>
 						</div>
 
@@ -691,6 +726,28 @@ function OrdersByTimeslotViewInner() {
 												)}
 											</td>
 											<td style={{ padding: "10px 12px", textAlign: "right" }}>
+												{order.files?.some(
+													(f) => f.stagingKey || f.permanentKey,
+												) && (
+													<button
+														type="button"
+														onClick={() => handleDownloadOrderFiles(order)}
+														title="Download all files for this order"
+														style={{
+															padding: "4px 12px",
+															background: "#00695c",
+															color: "#fff",
+															border: "none",
+															borderRadius: "4px",
+															fontSize: "12px",
+															fontWeight: 600,
+															cursor: "pointer",
+															marginRight: "4px",
+														}}
+													>
+														⬇ Download All
+													</button>
+												)}
 												{order.status === OrderStatus.AWAITING_PICKUP && (
 													<button
 														type="button"


### PR DESCRIPTION
## Summary

Two small admin improvements to the **Orders by Pickup Timeslot** view (`components/admin/OrdersByTimeslotView.tsx`):

1. **Open the timeslot document** — each timeslot header now has a **⚙ Manage Timeslot** link that opens `/admin/collections/timeslots/{id}`, the Payload document edit view. This is where the existing `DeleteTimeslotButton` (delete + notify customers) lives, so admins can jump straight there from the list.
2. **Download all files for a single order** — added a **⬇ Download All** button in each order's Actions column. It reuses the shared download logic (parallel presign, sequential open with a small delay to avoid popup blockers). Only shown when the order has downloadable files.

## Implementation notes

- Refactored the existing per-timeslot download into a shared `downloadFilesForOrders(orders)` helper. Both `handleDownloadAllFiles` (whole timeslot) and the new `handleDownloadOrderFiles` (single order) delegate to it, keeping behaviour identical.
- The in-place delete was intentionally **not** implemented in this view: `DeleteTimeslotButton` depends on Payload's `useDocumentInfo()` hook, which is only available inside a Payload document context. Linking to the document view is the correct integration point.

## Testing

- `tsc --noEmit` passes with no errors.
- `biome check` clean.