### PR TITLE
fix(orders): let customers change pickup slot on PRINTED orders (frontend)

### DIFF
--- a/components/ordercontainer/OrderContainer.tsx
+++ b/components/ordercontainer/OrderContainer.tsx
@@ -114,11 +114,15 @@ const OrderContainerInner = ({
 				setActiveOrderId(order.id);
 				setActiveOrderNumber(order.orderNumber);
 
-				// If pickupFor query param, force pickup step (if order is PAID or AWAITING_PICKUP)
+				// If pickupFor query param, force pickup step so the customer can
+				// (re)select their timeslot. PRINTED orders are still allowed to
+				// change their slot (see select-timeslot route), so include it here
+				// too — otherwise statusToStep would send them to COMPLETE.
 				if (
 					pickupForOrderId &&
 					(order.status === OrderStatus.PAID ||
-						order.status === OrderStatus.AWAITING_PICKUP)
+						order.status === OrderStatus.AWAITING_PICKUP ||
+						order.status === OrderStatus.PRINTED)
 				) {
 					setOrderStep(OrderStep.PICKUP);
 				} else {

--- a/pages/my-orders.tsx
+++ b/pages/my-orders.tsx
@@ -170,7 +170,10 @@ const MyOrders: NextPage<PageProps> = ({ contactInfo }) => {
 				</Button>
 			);
 		}
-		if (order.status === OrderStatus.AWAITING_PICKUP) {
+		if (
+			order.status === OrderStatus.AWAITING_PICKUP ||
+			order.status === OrderStatus.PRINTED
+		) {
 			return (
 				<Button
 					size="sm"


### PR DESCRIPTION
## Problem
[PR #100](https://github.com/choden-dev/PrimalPrinting/pull/100) updated the `POST /api/shop/:orderId/select-timeslot` endpoint to accept `PRINTED` orders, so the backend now supports customers changing their pickup slot after an admin has printed the order.

However, the **customer-facing frontend never surfaced a way to trigger this**, so in practice only admins could change the timeslot of a printed order. Two frontend touchpoints gated on `PAID`/`AWAITING_PICKUP` only:

1. `pages/my-orders.tsx` — the **Change Pickup** button in `renderOrderAction` was only rendered for `PAID` and `AWAITING_PICKUP` orders. A customer with a `PRINTED` order saw no action button.
2. `components/ordercontainer/OrderContainer.tsx` — navigating via `?pickupFor=<id>` only forced the `PICKUP` step for `PAID`/`AWAITING_PICKUP`. For a `PRINTED` order, `statusToStep()` returned `COMPLETE`, dropping the user on the confirmation screen instead of the timeslot picker.

## Fix
- `my-orders.tsx`: show the **Change Pickup** button for `PRINTED` orders too.
- `OrderContainer.tsx`: force the `PICKUP` step for `PRINTED` orders when arriving via `?pickupFor=`.

The `PICKUP` step in `OrderSteps.tsx` already renders `TimeslotSelector` unconditionally (and `OrderSteps` already allows staying on the PICKUP step for `PRINTED`), so no further changes were needed once the step is reached. The COMPLETE step's existing **Change Pickup** button also now works end-to-end for printed orders.

## Testing
- `biome check` passes on both changed files.
- `tsc --noEmit` passes with no errors.
- Pre-commit and pre-push hooks passed.